### PR TITLE
Replacing deprecated rx.plugins.RxJavaPlugins.getInstance()  

### DIFF
--- a/rx-java/src/main/java/examples/NativeExamples.java
+++ b/rx-java/src/main/java/examples/NativeExamples.java
@@ -18,6 +18,7 @@ import rx.Scheduler;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.plugins.RxJavaSchedulersHook;
+import rx.plugins.RxJavaHooks;
 
 import java.util.concurrent.TimeUnit;
 
@@ -96,7 +97,9 @@ public class NativeExamples {
 
   public void schedulerHook(Vertx vertx) {
     RxJavaSchedulersHook hook = RxHelper.schedulerHook(vertx);
-    rx.plugins.RxJavaPlugins.getInstance().registerSchedulersHook(hook);
+    RxJavaHooks.setOnIOScheduler(f -> hook.getIOScheduler());
+    RxJavaHooks.setOnNewThreadScheduler(f -> hook.getNewThreadScheduler());
+    RxJavaHooks.setOnComputationScheduler(f -> hook.getComputationScheduler());
   }
 
   private class MyPojo {

--- a/rx-java/src/main/java/examples/RxifiedExamples.java
+++ b/rx-java/src/main/java/examples/RxifiedExamples.java
@@ -24,6 +24,7 @@ import rx.Scheduler;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.plugins.RxJavaSchedulersHook;
+import rx.plugins.RxJavaHooks;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -63,7 +64,9 @@ public class RxifiedExamples {
 
   public void schedulerHook(Vertx vertx) {
     RxJavaSchedulersHook hook = io.vertx.rxjava.core.RxHelper.schedulerHook(vertx);
-    rx.plugins.RxJavaPlugins.getInstance().registerSchedulersHook(hook);
+      RxJavaHooks.setOnIOScheduler(f -> hook.getIOScheduler());
+      RxJavaHooks.setOnNewThreadScheduler(f -> hook.getNewThreadScheduler());
+      RxJavaHooks.setOnComputationScheduler(f -> hook.getComputationScheduler());
   }
 
   public void unmarshaller(FileSystem fileSystem) {


### PR DESCRIPTION
Replacing deprecated rx.plugins.RxJavaPlugins.getInstance() in examples with  rx.plugins.RxJavaHooks.