### PR TITLE
Generics improvements

### DIFF
--- a/rx-java/src/main/asciidoc/dataobjects.adoc
+++ b/rx-java/src/main/asciidoc/dataobjects.adoc
@@ -873,9 +873,34 @@ Set whether client auth is required
 +++
 Set whether client auth is required
 +++
+|[[compressionLevel]]`compressionLevel`|`Number (int)`|
++++
+This method allows to set the compression level to be used in http1.x/2 response bodies 
+ when compression support is turned on (@see setCompressionSupported) and the client advertises
+ to support <code>deflate/gzip</code> compression in the <code>Accept-Encoding</code> header
+ 
+ default value is : 6 (Netty legacy)
+ 
+ The compression level determines how much the data is compressed on a scale from 1 to 9,
+ where '9' is trying to achieve the maximum compression ratio while '1' instead is giving
+ priority to speed instead of compression ratio using some algorithm optimizations and skipping 
+ pedantic loops that usually gives just little improvements
+ 
+ While one can think that best value is always the maximum compression ratio, 
+ there's a trade-off to consider: the most compressed level requires the most
+ computatinal work to compress/decompress data, e.g. more dictionary lookups and loops.
+ 
+ E.g. you have it set fairly high on a high-volume website, you may experience performance degradation 
+ and latency on resource serving due to CPU overload, and, however - as the comptational work is required also client side 
+ while decompressing - setting an higher compression level can result in an overall higher page load time
+ especially nowadays when many clients are handled mobile devices with a low CPU profile.
+ 
+ see also: http://www.gzip.org/algorithm.txt
++++
 |[[compressionSupported]]`compressionSupported`|`Boolean`|
 +++
-Set whether the server supports compression
+Set whether the server should support gzip/deflate compression 
+ (serving compressed responses to clients advertising support for them with Accept-Encoding header)
 +++
 |[[crlPaths]]`crlPaths`|`Array of String`|
 +++
@@ -884,6 +909,10 @@ Add a CRL path
 |[[crlValues]]`crlValues`|`Array of Buffer`|
 +++
 Add a CRL value
++++
+|[[decompressionSupported]]`decompressionSupported`|`Boolean`|
++++
+Set whether the server supports decompression
 +++
 |[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
 +++

--- a/rx-java/src/main/java/io/vertx/lang/rxjava/TypeArg.java
+++ b/rx-java/src/main/java/io/vertx/lang/rxjava/TypeArg.java
@@ -1,0 +1,21 @@
+package io.vertx.lang.rxjava;
+
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class TypeArg<T> {
+
+  public static <T> TypeArg<T> unknown() {
+    return new TypeArg<>(obj -> (T)obj, obj -> obj);
+  }
+
+  public final Function<Object, T> toJava; // wrap ???
+  public final Function<T, Object> unwrap;
+
+  public TypeArg(Function<Object, T> toJava, Function<T, Object> unwrap) {
+    this.toJava = toJava;
+    this.unwrap = unwrap;
+  }
+}

--- a/rx-java/src/main/java/io/vertx/lang/rxjava/TypeArg.java
+++ b/rx-java/src/main/java/io/vertx/lang/rxjava/TypeArg.java
@@ -11,11 +11,11 @@ public class TypeArg<T> {
     return new TypeArg<>(obj -> (T)obj, obj -> obj);
   }
 
-  public final Function<Object, T> toJava; // wrap ???
+  public final Function<Object, T> wrap;
   public final Function<T, Object> unwrap;
 
-  public TypeArg(Function<Object, T> toJava, Function<T, Object> unwrap) {
-    this.toJava = toJava;
+  public TypeArg(Function<Object, T> wrap, Function<T, Object> unwrap) {
+    this.wrap = wrap;
     this.unwrap = unwrap;
   }
 }

--- a/rx-java/src/main/resources/vertx-rxjava/template/class.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/class.templ
@@ -89,6 +89,16 @@ public @if{concrete}class@else{}interface@end{} @{helper.getSimpleName(ifaceFQCN
   public static @if{typeParams.size() > 0}<@foreach{typeParam:typeParams}@{typeParam.name}@end{', '}> @end{}@{type.simpleName} newInstance(@{type.raw.name} arg) {\n
     return arg != null ? new @{type.raw.simpleName + (concrete ? '' : 'Impl')}@if{typeParams.size() > 0}<@foreach{typeParam:typeParams}@{typeParam.name}@end{', '}> @end{}(arg) : null;\n
   }\n
+@if{type.params.size() > 0}
+\n
+  public static @if{typeParams.size() > 0}<@foreach{typeParam:typeParams}@{typeParam.name}@end{', '}> @end{}@{type.simpleName} newInstance(@{type.raw.name} arg@foreach{typeParam:type.params}
+, io.vertx.lang.rxjava.TypeArg<@{typeParam.name}> typeArg_@{typeParam.name}
+@end{}) {\n
+    return arg != null ? new @{type.raw.simpleName + (concrete ? '' : 'Impl')}@if{typeParams.size() > 0}<@foreach{typeParam:typeParams}@{typeParam.name}@end{', '}> @end{}(arg@foreach{typeParam:typeParams}
+, typeArg_@{typeParam.name}
+@end{}) : null;\n
+  }\n
+@end{}
 }\n
 
 @if{!concrete}

--- a/rx-java/src/main/resources/vertx-rxjava/template/classbody.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/classbody.templ
@@ -1,10 +1,37 @@
-	  final @{helper.getNonGenericType(ifaceFQCN)} delegate;\n\n
+	@if{concrete && type.params.empty}
+	  public static final io.vertx.lang.rxjava.TypeArg<@{type.simpleName}> arg = new io.vertx.lang.rxjava.TypeArg<>(\n
+	    obj -> new @{type.simpleName}((@{type.name}) obj),\n
+	    obj -> obj.getDelegate()\n
+	  );\n
+	\n
+	@end{}
+	  final @{helper.getNonGenericType(ifaceFQCN)} delegate;\n
+	@foreach{typeParam:type.params}
+	  private io.vertx.lang.rxjava.TypeArg<@{typeParam.name}> typeArg_@{typeParam.name};\n
+	@end{}
+	  \n
 	  public @{constructor}(@{helper.getNonGenericType(ifaceFQCN)} delegate) {\n
 	@if{concrete && concreteSuperType != null}
 	    super(delegate);\n
 	@end{}
 	    this.delegate = delegate;\n
+	@foreach{typeParam:type.params}
+	    this.typeArg_@{typeParam.name} = io.vertx.lang.rxjava.TypeArg.unknown();\n
+	@end{}
 	  }\n\n
+	@if{type.params.size() > 0}
+	  public @{constructor}(@{helper.getNonGenericType(ifaceFQCN)} delegate@foreach{typeParam:type.params}
+		, io.vertx.lang.rxjava.TypeArg<@{typeParam.name}> typeArg_@{typeParam.name}
+		@end{}) {\n
+	@if{concrete && concreteSuperType != null}
+	    super(delegate);\n
+	@end{}
+	    this.delegate = delegate;\n
+	@foreach{typeParam:type.params}
+	    this.typeArg_@{typeParam.name} = typeArg_@{typeParam.name};\n
+	@end{}
+	  }\n\n
+	@end{}
 
 	  public Object getDelegate() {\n
 	    return delegate;\n

--- a/rx-java/src/main/resources/vertx-rxjava/template/common.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/common.templ
@@ -124,7 +124,7 @@
     if (type.kind == CLASS_OBJECT) {
       if (type.variable) {
         if (type.classParam) {
-          return 'typeArg_' + type.name + '.toJava.apply(' + expr + ')';
+          return 'typeArg_' + type.name + '.wrap.apply(' + expr + ')';
         }
       }
       return '(' + type.simpleName + ') ' + expr;

--- a/rx-java/src/main/resources/vertx-rxjava/template/common.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/common.templ
@@ -58,7 +58,7 @@
 
   function isSameType(type) {
     var kind = type.kind;
-    if (kind.basic || kind.json || kind == CLASS_OBJECT || kind == CLASS_DATA_OBJECT || kind == CLASS_ENUM || kind == CLASS_OTHER || kind == CLASS_THROWABLE || kind == CLASS_VOID) {
+    if (kind.basic || kind.json || (kind == CLASS_OBJECT && !type.variable) || kind == CLASS_DATA_OBJECT || kind == CLASS_ENUM || kind == CLASS_OTHER || kind == CLASS_THROWABLE || kind == CLASS_VOID) {
       return true;
     } else if (kind == CLASS_LIST || kind == CLASS_SET || kind == CLASS_ASYNC_RESULT) {
       return isSameType(type.args[0]);
@@ -71,6 +71,11 @@
   function genConvParam(type, expr) {
     var kind = type.kind;
     if (isSameType(type)) {
+      return expr;
+    } else if (kind == CLASS_OBJECT) {
+      if (type.classParam) {
+        return 'typeArg_' + type.name + '.unwrap.apply(' + expr + ')';
+      }
       return expr;
     } else if (kind == CLASS_HANDLER) {
       var eventType = type.args[0];
@@ -117,11 +122,30 @@
 
   function genConvReturn(type, expr) {
     if (type.kind == CLASS_OBJECT) {
+      if (type.variable) {
+        if (type.classParam) {
+          return 'typeArg_' + type.name + '.toJava.apply(' + expr + ')';
+        }
+      }
       return '(' + type.simpleName + ') ' + expr;
     } else if (isSameType(type)) {
       return expr;
     } else if (type.kind == CLASS_API) {
-      return type.raw.simpleName + '.newInstance(' + expr + ')';
+      var tmp = new StringBuilder(type.raw.simpleName);
+      tmp.append('.newInstance(');
+      tmp.append(expr);
+      if (type.parameterized) {
+        for (arg : type.args) {
+          tmp.append(', ');
+          if (arg.kind == CLASS_API) {
+            tmp.append(arg.translateName('rxjava')).append('.arg');
+          } else {
+            tmp.append('io.vertx.lang.rxjava.TypeArg.unknown()');
+          }
+        }
+      }
+      tmp.append(')');
+      return tmp.toString();
     } else if (type.kind == CLASS_HANDLER) {
       var abc = type.args[0];
       if (abc.kind == CLASS_ASYNC_RESULT) {

--- a/rx-java/src/test/java/io/vertx/rx/java/test/JavaIntegrationTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/JavaIntegrationTest.java
@@ -530,7 +530,6 @@ public class JavaIntegrationTest extends VertxTestBase {
     await();
   }
 
-  @Test
   public void testHttpClientFlatMap() {
     HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(8080));
     server.requestStream().handler(req -> {

--- a/rx-java/src/test/java/io/vertx/rx/java/test/JavaIntegrationTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/JavaIntegrationTest.java
@@ -530,6 +530,7 @@ public class JavaIntegrationTest extends VertxTestBase {
     await();
   }
 
+  @Test
   public void testHttpClientFlatMap() {
     HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(8080));
     server.requestStream().handler(req -> {

--- a/rx-java/src/test/java/io/vertx/rx/java/test/api/GenericsTCKTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/api/GenericsTCKTest.java
@@ -1,0 +1,30 @@
+package io.vertx.rx.java.test.api;
+
+import io.vertx.codegen.testmodel.GenericsTCKImpl;
+import io.vertx.codegen.testmodel.RefedInterface1Impl;
+import io.vertx.rxjava.codegen.testmodel.GenericRefedInterface;
+import io.vertx.rxjava.codegen.testmodel.GenericsTCK;
+import io.vertx.rxjava.codegen.testmodel.RefedInterface1;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class GenericsTCKTest {
+
+  final GenericsTCK obj = new GenericsTCK(new GenericsTCKImpl());
+
+  @Test
+  public void testMethodWithUserTypeParameterizedReturn() {
+    GenericRefedInterface<RefedInterface1> gen = obj.methodWithUserTypeParameterizedReturn();
+    RefedInterface1 refed = gen.getValue();
+    assertEquals("foo", refed.getString());
+    refed = new RefedInterface1(new RefedInterface1Impl());
+    refed.setString("the_string");
+    gen.setValue(refed);
+    refed = gen.getValue();
+    assertEquals("the_string", refed.getString());
+  }
+}


### PR DESCRIPTION
Provides support for `GenericApi<String>` as argument and return types and support for `<U> GenericApi<U> m(Class<U>)` or even `U m(Class<U>)`