### PR TITLE
Use Completable instead of Single<Void> - fixes #77

### DIFF
--- a/rx-java/src/main/asciidoc/java/index.adoc
+++ b/rx-java/src/main/asciidoc/java/index.adoc
@@ -85,7 +85,7 @@ it to an `Observable` or a `Single`:
 ----
 observable.subscribe(RxHelper.toSubscriber(handler1));
 
-//
+// Subscribe to a Single
 single.subscribe(RxHelper.toSubscriber(handler2));
 ----
 

--- a/rx-java/src/main/asciidoc/java/index.adoc
+++ b/rx-java/src/main/asciidoc/java/index.adoc
@@ -171,7 +171,25 @@ single.
     );
 ----
 
-Such single are *cold* singles, and the corresponding API method is called on subscribe.
+For `Void` type an RxJava `Completable` is used instead:
+
+[source,java]
+----
+Completable completable = server.rxClose();
+
+// Subscribe to close the server
+completable.
+  subscribe(
+    () -> {
+      // Server is closed
+    },
+    failure -> {
+      // Server could not stop
+    }
+  );
+----
+
+Such reactive types are *cold*, and the corresponding API method is called on subscribe.
 
 NOTE: the `rx*` methods replace the `*Observable` of the previous _Rxified_ versions with a semantic
 change to be more in line with RxJava.

--- a/rx-java/src/main/java/examples/RxifiedExamples.java
+++ b/rx-java/src/main/java/examples/RxifiedExamples.java
@@ -21,6 +21,7 @@ import io.vertx.rxjava.core.http.HttpServer;
 import io.vertx.rxjava.core.http.HttpServerRequest;
 import io.vertx.rxjava.core.http.ServerWebSocket;
 import io.vertx.rxjava.core.http.WebSocket;
+import rx.Completable;
 import rx.Observable;
 import rx.Scheduler;
 import rx.Single;
@@ -63,6 +64,23 @@ public class RxifiedExamples {
               // Server could not start
             }
         );
+  }
+
+  public void completable(HttpServer server) {
+
+    // Obtain a completable that performs the actual close on subscribe
+    Completable completable = server.rxClose();
+
+    // Subscribe to close the server
+    completable.
+      subscribe(
+        () -> {
+          // Server is closed
+        },
+        failure -> {
+          // Server could not stop
+        }
+      );
   }
 
   public void scheduler(Vertx vertx) {

--- a/rx-java/src/main/java/io/vertx/rx/java/CompletableOnSubscribeAdapter.java
+++ b/rx-java/src/main/java/io/vertx/rx/java/CompletableOnSubscribeAdapter.java
@@ -1,0 +1,36 @@
+package io.vertx.rx.java;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import rx.Completable;
+import rx.CompletableSubscriber;
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.subscriptions.BooleanSubscription;
+
+import java.util.function.Consumer;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class CompletableOnSubscribeAdapter implements Completable.OnSubscribe {
+
+  protected final Consumer<Handler<AsyncResult<Void>>> consumer;
+
+  public CompletableOnSubscribeAdapter(Consumer<Handler<AsyncResult<Void>>> consumer) {
+    this.consumer = consumer;
+  }
+
+  // OnSubscribe
+
+  @Override
+  public void call(CompletableSubscriber sub) {
+    consumer.accept(ar -> {
+      if (ar.succeeded()) {
+        sub.onCompleted();
+      } else {
+        sub.onError(ar.cause());
+      }
+    });
+  }
+}

--- a/rx-java/src/main/java/io/vertx/rxjava/core/package-info.java
+++ b/rx-java/src/main/java/io/vertx/rxjava/core/package-info.java
@@ -108,7 +108,14 @@
  * {@link examples.RxifiedExamples#single(io.vertx.rxjava.core.Vertx)}
  * ----
  *
- * Such single are *cold* singles, and the corresponding API method is called on subscribe.
+ * For `Void` type an RxJava {@code Completable} is used instead:
+ *
+ * [source,java]
+ * ----
+ * {@link examples.RxifiedExamples#completable}
+ * ----
+ *
+ * Such reactive types are *cold*, and the corresponding API method is called on subscribe.
  *
  * NOTE: the `rx*` methods replace the `*Observable` of the previous _Rxified_ versions with a semantic
  * change to be more in line with RxJava.

--- a/rx-java/src/main/resources/vertx-rxjava/template/class.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/class.templ
@@ -22,6 +22,7 @@ package @{type.raw.translatePackageName("rxjava")};\n\n
 @code{cacheDecls=new java.util.ArrayList()}
 
 import java.util.Map;\n
+import rx.Completable;\n
 import rx.Observable;\n
 import rx.Single;\n
 @comment{"Generate the imports"}

--- a/rx-java/src/main/resources/vertx-rxjava/template/common.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/common.templ
@@ -223,7 +223,12 @@
     }
     var futParam = method.params[size];
     var futType = futParam.type.args[0].args[0];
-    var futReturnType = new io.vertx.codegen.type.ParameterizedTypeInfo(io.vertx.codegen.type.TypeReflectionFactory.create(rx.Single), false, java.util.Collections.singletonList(futType));
+    var futReturnType;
+    if (futType.name == 'java.lang.Void') {
+      futReturnType = io.vertx.codegen.type.TypeReflectionFactory.create(rx.Completable);
+    } else {
+      futReturnType = new io.vertx.codegen.type.ParameterizedTypeInfo(io.vertx.codegen.type.TypeReflectionFactory.create(rx.Single), false, java.util.Collections.singletonList(futType));
+    }
     var futMethod = new io.vertx.codegen.MethodInfo(
       method.ownerTypes, futMethodName,
       method.kind,
@@ -346,23 +351,25 @@
 
 @declare{'genMethod'}
 	@includeNamed{'genSimpleMethod'}
-	@if{method.kind == METHOD_FUTURE && options.get('codegen.rxjava.deprecated') == 'true'}
-		@code{methodName=method.name}
+	@if{method.kind == METHOD_FUTURE}
 		@code{futureParams=new java.util.ArrayList(method.params)}
 		@code{futureParam=futureParams.remove(futureParams.size()-1)}
 		@code{futureType=futureParam.type.args[0].args[0]}
-		@code{futureReturnType=new io.vertx.codegen.type.ParameterizedTypeInfo(io.vertx.codegen.type.TypeReflectionFactory.create(rx.Observable), false, java.util.Collections.singletonList(futureType))}
-		@code{futureMethod=new io.vertx.codegen.MethodInfo(method.ownerTypes,method.name + 'Observable',method.kind,futureReturnType,null,method.fluent,method.cacheReturn,futureParams,method.comment,method.doc,method.staticMethod,method.defaultMethod,method.typeParams)}
-		@includeNamed{'startMethodTemplate';meth=futureMethod;deprecated='use {@link #' + genFutureMethodName(method) + '} instead'} { \n
-		    io.vertx.rx.java.ObservableFuture<@{futureType.simpleName}> @{futureParam.name} = io.vertx.rx.java.RxHelper.observableFuture();\n
-		    @{methodName}(@foreach{param:futureParams}@{param.name}@end{', '}@if{futureParams.size() > 0}, @end{}@{futureParam.name}.toHandler());\n
-		    return @{futureParam.name};\n
-		  }\n\n
-	@end{}
-	@if{method.kind == METHOD_FUTURE}
+		@if{options.get('codegen.rxjava.deprecated') == 'true'}
+			@code{methodName=method.name}
+			@code{futureReturnType=new io.vertx.codegen.type.ParameterizedTypeInfo(io.vertx.codegen.type.TypeReflectionFactory.create(rx.Observable), false, java.util.Collections.singletonList(futureType))}
+			@code{futureMethod=new io.vertx.codegen.MethodInfo(method.ownerTypes,method.name + 'Observable',method.kind,futureReturnType,null,method.fluent,method.cacheReturn,futureParams,method.comment,method.doc,method.staticMethod,method.defaultMethod,method.typeParams)}
+			@includeNamed{'startMethodTemplate';meth=futureMethod;deprecated='use {@link #' + genFutureMethodName(method) + '} instead'} { \n
+			    io.vertx.rx.java.ObservableFuture<@{futureType.simpleName}> @{futureParam.name} = io.vertx.rx.java.RxHelper.observableFuture();\n
+			    @{methodName}(@foreach{param:futureParams}@{param.name}@end{', '}@if{futureParams.size() > 0}, @end{}@{futureParam.name}.toHandler());\n
+			    return @{futureParam.name};\n
+			  }\n\n
+		@end{}
 		@code{futMeth = genFutureMethod(method)}
+		@code{foobar = futureType.name == 'java.lang.Void' ? 'Completable' : 'Single'}
+		@code{foojuu = futureType.name  == 'java.lang.Void' ? 'CompletableOnSubscribeAdapter' : 'SingleOnSubscribeAdapter<>'}
 		@includeNamed{'startMethodTemplate';meth=futMeth;deprecated=''} { \n
-		    return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {\n
+		    return @{foobar}.create(new io.vertx.rx.java.@{foojuu}(fut -> {\n
 		      @{method.name}(@foreach{param:futMeth.params}@{param.name}@end{', '}@if{futMeth.params.size() > 0}, @end{}fut);\n
 		    }));\n
 		  }\n\n

--- a/rx-java/src/test/java/io/vertx/rx/java/test/CoreRxifiedApiTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/CoreRxifiedApiTest.java
@@ -16,9 +16,9 @@
 package io.vertx.rx.java.test;
 
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.rxjava.core.AbstractVerticle;
 import io.vertx.rxjava.core.Vertx;
 import io.vertx.rxjava.core.http.HttpServer;
-import io.vertx.rxjava.core.AbstractVerticle;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 import rx.Observable;
@@ -57,6 +57,26 @@ public class CoreRxifiedApiTest extends VertxTestBase {
   }
 
   @Test
+  public void testDeployWithSingleAndCompletable() throws Exception {
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(8080)).requestHandler(req -> {
+        });
+        server.rxListen()
+          .subscribe(
+            result -> server
+              .rxClose()
+              .subscribe(
+                () -> testComplete(),
+                err -> fail(err)),
+            err -> fail(err));
+      }
+    });
+    await();
+  }
+
+  @Test
   public void testObservablePeriodic() throws Exception {
     Vertx vertx = new Vertx(this.vertx);
     Observable<Long> stream = vertx.periodicStream(1).toObservable();
@@ -66,10 +86,12 @@ public class CoreRxifiedApiTest extends VertxTestBase {
         unsubscribe();
         testComplete();
       }
+
       @Override
       public void onCompleted() {
         fail();
       }
+
       @Override
       public void onError(Throwable e) {
         fail(e.getMessage());


### PR DESCRIPTION
Motivation:

the new _rxABC_ methods generate `Single<Void>`, RxJava provides the `Completable` type that is the right rx type that should be used.

Changes:

now the generator creates `Completable` types instead of `Single<Void>` with the corresponding adapter.