### PR TITLE
Invoke equals, hashCode and toString on delegate

### DIFF
--- a/rx-java/src/main/resources/vertx-rxjava/template/class.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/class.templ
@@ -88,6 +88,14 @@ public @if{concrete}class@else{}interface@end{} @{helper.getSimpleName(ifaceFQCN
 	\n
 	@end{}
 
+	@if{!hasToString(methods)}
+	  @Override\n
+	  public String toString() {\n
+	    return delegate.toString();\n
+	  }\n
+	\n
+	@end{}
+
 	  @Override\n
 	  public boolean equals(Object o) {\n
 	    if (this == o) return true;\n

--- a/rx-java/src/main/resources/vertx-rxjava/template/class.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/class.templ
@@ -76,15 +76,31 @@ public @if{concrete}class@else{}interface@end{} @{helper.getSimpleName(ifaceFQCN
 @if{concrete}
 
 	@if{type.name == 'io.vertx.core.buffer.Buffer'}
-	    public void writeToBuffer(io.vertx.core.buffer.Buffer buffer) {\n
-	      delegate.writeToBuffer(buffer);\n
-	    }\n
+	  @Override\n
+	  public void writeToBuffer(io.vertx.core.buffer.Buffer buffer) {\n
+	    delegate.writeToBuffer(buffer);\n
+	  }\n
 	\n
-	    public int readFromBuffer(int pos, io.vertx.core.buffer.Buffer buffer) {\n
-	      return delegate.readFromBuffer(pos, buffer);\n
-	    }\n
+	  @Override\n
+	  public int readFromBuffer(int pos, io.vertx.core.buffer.Buffer buffer) {\n
+	    return delegate.readFromBuffer(pos, buffer);\n
+	  }\n
 	\n
 	@end{}
+
+	  @Override\n
+	  public boolean equals(Object o) {\n
+	    if (this == o) return true;\n
+	    if (o == null || getClass() != o.getClass()) return false;\n
+	    @{type.simpleName} that = (@{type.simpleName}) o;\n
+	    return delegate.equals(that.delegate);\n
+	  }\n
+	  \n
+	  @Override\n
+	  public int hashCode() {\n
+	    return delegate.hashCode();\n
+	  }\n
+	\n
 
 	@includeNamed{'classbody.templ';constructor=ifaceSimpleName}
 

--- a/rx-java/src/main/resources/vertx-rxjava/template/common.templ
+++ b/rx-java/src/main/resources/vertx-rxjava/template/common.templ
@@ -238,6 +238,15 @@
       return deflt;
     }
   }
+
+  def hasToString(methods) {
+    for (method : methods) {
+      if (method.name == 'toString' && method.params.isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 @declare{'startMethodTemplate'}

--- a/rx-java/src/test/java/io/vertx/codegen/extra/ConcreteInheritsToString.java
+++ b/rx-java/src/test/java/io/vertx/codegen/extra/ConcreteInheritsToString.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Thomas Segismont
+ */
+@VertxGen
+public interface ConcreteInheritsToString extends NonConcreteWithToString {
+  void doSomething();
+}

--- a/rx-java/src/test/java/io/vertx/codegen/extra/ConcreteOverridesToString.java
+++ b/rx-java/src/test/java/io/vertx/codegen/extra/ConcreteOverridesToString.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Thomas Segismont
+ */
+@VertxGen
+public interface ConcreteOverridesToString extends NonConcreteWithToString {
+  void doSomething();
+  /**
+   * My even more special toString method
+   */
+  String toString();
+}

--- a/rx-java/src/test/java/io/vertx/codegen/extra/NonConcreteWithToString.java
+++ b/rx-java/src/test/java/io/vertx/codegen/extra/NonConcreteWithToString.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Thomas Segismont
+ */
+@VertxGen(concrete = false)
+public interface NonConcreteWithToString {
+  /**
+   * My very special toString method
+   */
+  String toString();
+}

--- a/rx-java/src/test/java/io/vertx/rx/java/test/EqualityTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/EqualityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.rx.java.test;
+
+import com.acme.rxjava.pkg.AnotherInterface;
+import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.rxjava.core.buffer.Buffer;
+import io.vertx.rxjava.core.net.SocketAddress;
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class EqualityTest {
+
+  @Test
+  public void testBufferEquality() {
+    Buffer buf1 = Buffer.buffer("The quick brown fox jumps over the lazy dog");
+    Buffer buf2 = buf1.copy();
+    assertNotSame(buf1, buf2);
+    assertEquals(buf1, buf2);
+  }
+
+  @Test
+  public void testBufferSet() {
+    Buffer buf1 = Buffer.buffer("The quick brown fox jumps over the lazy dog");
+    Buffer buf2 = buf1.copy();
+    assertEquals(1, Stream.of(buf1, buf2).collect(toSet()).size());
+  }
+
+  @Test
+  public void testSocketAddressEquality() {
+    SocketAddress address1 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    SocketAddress address2 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    assertNotSame(address1, address2);
+    assertEquals(address1, address2);
+  }
+
+  @Test
+  public void testSocketAddressSet() {
+    SocketAddress address1 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    SocketAddress address2 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    assertEquals(1, Stream.of(address1, address2).collect(toSet()).size());
+  }
+
+  @Test
+  public void testAnotherInterfaceEquality() {
+    AnotherInterface ai1 = AnotherInterface.create();
+    AnotherInterface ai2 = AnotherInterface.create();
+    assertNotSame(ai1, ai2);
+    assertNotEquals(ai1, ai2);
+  }
+
+  @Test
+  public void testAnotherInterfaceSet() {
+    AnotherInterface ai1 = AnotherInterface.create();
+    AnotherInterface ai2 = AnotherInterface.create();
+    assertEquals(2, Stream.of(ai1, ai2).collect(toSet()).size());
+  }
+}

--- a/rx-java/src/test/java/io/vertx/rx/java/test/ToStringTest.java
+++ b/rx-java/src/test/java/io/vertx/rx/java/test/ToStringTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.rx.java.test;
+
+import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.rxjava.core.buffer.Buffer;
+import io.vertx.rxjava.core.net.SocketAddress;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ToStringTest {
+
+  @Test
+  public void testBufferToString() {
+    String string = "The quick brown fox jumps over the lazy dog";
+    assertEquals(string, Buffer.buffer(string).toString());
+  }
+
+  @Test
+  public void testSocketAddressToString() {
+    io.vertx.core.net.SocketAddress socketAddress = new SocketAddressImpl(8888, "guest");
+    SocketAddress rxSocketAddress = SocketAddress.newInstance(socketAddress);
+    assertEquals(socketAddress.toString(), rxSocketAddress.toString());
+  }
+}

--- a/rx-java2/src/test/java/io/vertx/reactivex/test/EqualityTest.java
+++ b/rx-java2/src/test/java/io/vertx/reactivex/test/EqualityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.reactivex.test;
+
+import com.acme.reactivex.pkg.AnotherInterface;
+import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.net.SocketAddress;
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class EqualityTest {
+
+  @Test
+  public void testBufferEquality() {
+    Buffer buf1 = Buffer.buffer("The quick brown fox jumps over the lazy dog");
+    Buffer buf2 = buf1.copy();
+    assertNotSame(buf1, buf2);
+    assertEquals(buf1, buf2);
+  }
+
+  @Test
+  public void testBufferSet() {
+    Buffer buf1 = Buffer.buffer("The quick brown fox jumps over the lazy dog");
+    Buffer buf2 = buf1.copy();
+    assertEquals(1, Stream.of(buf1, buf2).collect(toSet()).size());
+  }
+
+  @Test
+  public void testSocketAddressEquality() {
+    SocketAddress address1 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    SocketAddress address2 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    assertNotSame(address1, address2);
+    assertEquals(address1, address2);
+  }
+
+  @Test
+  public void testSocketAddressSet() {
+    SocketAddress address1 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    SocketAddress address2 = SocketAddress.newInstance(new SocketAddressImpl(8888, "guest"));
+    assertEquals(1, Stream.of(address1, address2).collect(toSet()).size());
+  }
+
+  @Test
+  public void testAnotherInterfaceEquality() {
+    AnotherInterface ai1 = AnotherInterface.create();
+    AnotherInterface ai2 = AnotherInterface.create();
+    assertNotSame(ai1, ai2);
+    assertNotEquals(ai1, ai2);
+  }
+
+  @Test
+  public void testAnotherInterfaceSet() {
+    AnotherInterface ai1 = AnotherInterface.create();
+    AnotherInterface ai2 = AnotherInterface.create();
+    assertEquals(2, Stream.of(ai1, ai2).collect(toSet()).size());
+  }
+}

--- a/rx-java2/src/test/java/io/vertx/reactivex/test/ToStringTest.java
+++ b/rx-java2/src/test/java/io/vertx/reactivex/test/ToStringTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.reactivex.test;
+
+import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.net.SocketAddress;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ToStringTest {
+
+  @Test
+  public void testBufferToString() {
+    String string = "The quick brown fox jumps over the lazy dog";
+    assertEquals(string, Buffer.buffer(string).toString());
+  }
+
+  @Test
+  public void testSocketAddressToString() {
+    io.vertx.core.net.SocketAddress socketAddress = new SocketAddressImpl(8888, "guest");
+    SocketAddress rxSocketAddress = SocketAddress.newInstance(socketAddress);
+    assertEquals(socketAddress.toString(), rxSocketAddress.toString());
+  }
+}


### PR DESCRIPTION
Fixes #106

All generated classes now call equals/hashCode on the delegate.