### PR TITLE
expose AbstractVerticle's rxvertx instance

### DIFF
--- a/rx-java/src/main/java/io/vertx/rxjava/core/AbstractVerticle.java
+++ b/rx-java/src/main/java/io/vertx/rxjava/core/AbstractVerticle.java
@@ -74,5 +74,8 @@ public class AbstractVerticle extends io.vertx.core.AbstractVerticle {
    */
   public Completable rxStop() {
     return null;
+  
+  public io.vertx.rxjava.core.Vertx getRxVertx() {
+    return vertx;
   }
 }

--- a/rx-java2/src/main/java/io/vertx/reactivex/core/AbstractVerticle.java
+++ b/rx-java2/src/main/java/io/vertx/reactivex/core/AbstractVerticle.java
@@ -74,5 +74,8 @@ public class AbstractVerticle extends io.vertx.core.AbstractVerticle {
    */
   public Completable rxStop() {
     return null;
+  
+  public io.vertx.reactivex.core.Vertx getRxVertx() {
+    return vertx;
   }
 }


### PR DESCRIPTION
Add a method to `AbstractVerticle` to allow access to the rx.vertx instance for code other than that inheriting the class.