### PR TITLE
RxJava2 ObservableReadStream: set handlers before signaling subscription to the observer

### DIFF
--- a/rx-java2/src/main/java/io/vertx/reactivex/core/impl/ObservableReadStream.java
+++ b/rx-java2/src/main/java/io/vertx/reactivex/core/impl/ObservableReadStream.java
@@ -94,7 +94,7 @@ public class ObservableReadStream<T, U> extends Observable<U> {
       return;
     }
     Subscription sub = new Subscription(o);
-    o.onSubscribe(sub);
     sub.set();
+    o.onSubscribe(sub);
   }
 }

--- a/rx-java2/src/test/java/io/vertx/reactivex/test/FlowableReadStreamAdapterBackPressureTest.java
+++ b/rx-java2/src/test/java/io/vertx/reactivex/test/FlowableReadStreamAdapterBackPressureTest.java
@@ -1,14 +1,15 @@
 package io.vertx.reactivex.test;
 
 import io.reactivex.Flowable;
+import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.reactivex.FlowableHelper;
-import io.vertx.rx.java.ObservableReadStream;
 import io.vertx.rx.java.test.ReadStreamAdapterBackPressureTest;
 import io.vertx.rx.java.test.stream.BufferReadStreamImpl;
 import io.vertx.rx.java.test.support.SimpleSubscriber;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 /**
@@ -53,5 +54,23 @@ public class FlowableReadStreamAdapterBackPressureTest extends ReadStreamAdapter
       assertTrue(err instanceof IllegalStateException);
     });
     subscriber2.assertEmpty();
+  }
+
+  @Test
+  public void testHandletIsSetInDoOnSubscribe() {
+    AtomicBoolean hanlderSet = new AtomicBoolean();
+    BufferReadStreamImpl stream = new BufferReadStreamImpl() {
+      @Override
+      public BufferReadStreamImpl handler(Handler<Buffer> handler) {
+        hanlderSet.set(true);
+        return super.handler(handler);
+      }
+    };
+    Flowable<Buffer> observable = toObservable(stream).doOnSubscribe(disposable -> {
+      assertTrue(hanlderSet.get());
+    });
+    SimpleSubscriber<Buffer> subscriber = new SimpleSubscriber<>();
+    subscribe(observable, subscriber);
+    subscriber.assertEmpty();
   }
 }

--- a/rx-java2/src/test/java/io/vertx/reactivex/test/ObservableReadStreamAdapterTest.java
+++ b/rx-java2/src/test/java/io/vertx/reactivex/test/ObservableReadStreamAdapterTest.java
@@ -1,11 +1,15 @@
 package io.vertx.reactivex.test;
 
 import io.reactivex.Observable;
+import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.reactivex.ObservableHelper;
 import io.vertx.rx.java.test.ReadStreamAdapterTestBase;
 import io.vertx.rx.java.test.stream.BufferReadStreamImpl;
 import io.vertx.rx.java.test.support.SimpleSubscriber;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -35,5 +39,23 @@ public class ObservableReadStreamAdapterTest extends ReadStreamAdapterTestBase<B
   @Override
   protected Observable<Buffer> concat(Observable<Buffer> obs1, Observable<Buffer> obs2) {
     return Observable.concat(obs1, obs2);
+  }
+
+  @Test
+  public void testHandletIsSetInDoOnSubscribe() {
+    AtomicBoolean hanlderSet = new AtomicBoolean();
+    BufferReadStreamImpl stream = new BufferReadStreamImpl() {
+      @Override
+      public BufferReadStreamImpl handler(Handler<Buffer> handler) {
+        hanlderSet.set(true);
+        return super.handler(handler);
+      }
+    };
+    Observable<Buffer> observable = toObservable(stream).doOnSubscribe(disposable -> {
+      assertTrue(hanlderSet.get());
+    });
+    SimpleSubscriber<Buffer> subscriber = new SimpleSubscriber<>();
+    subscribe(observable, subscriber);
+    subscriber.assertEmpty();
   }
 }


### PR DESCRIPTION
Fixes #130