### PR TITLE
Makes sure assembly hooks are called when bridging a vertx type to an rxjava2 type

### DIFF
--- a/rx-java2-codegen/src/main/java/io/vertx/reactivex/FlowableHelper.java
+++ b/rx-java2-codegen/src/main/java/io/vertx/reactivex/FlowableHelper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.reactivex.impl.FlowableReadStream;
@@ -32,7 +33,7 @@ public class FlowableHelper {
    * Like {@link #toFlowable(ReadStream)} but with a {@code mapping} function
    */
   public static <T, U> Flowable<U> toFlowable(ReadStream<T> stream, Function<T, U> mapping) {
-    return new FlowableReadStream<>(stream, FlowableReadStream.DEFAULT_MAX_BUFFER_SIZE, mapping);
+    return RxJavaPlugins.onAssembly(new FlowableReadStream<>(stream, FlowableReadStream.DEFAULT_MAX_BUFFER_SIZE, mapping));
   }
 
   /**
@@ -44,7 +45,7 @@ public class FlowableHelper {
    * @return the adapted observable
    */
   public static <T> Flowable<T> toFlowable(ReadStream<T> stream) {
-    return new FlowableReadStream<>(stream, FlowableReadStream.DEFAULT_MAX_BUFFER_SIZE, Function.identity());
+    return RxJavaPlugins.onAssembly(new FlowableReadStream<>(stream, FlowableReadStream.DEFAULT_MAX_BUFFER_SIZE, Function.identity()));
   }
 
   /**
@@ -56,7 +57,7 @@ public class FlowableHelper {
    * @return the adapted observable
    */
   public static <T> Flowable<T> toFlowable(ReadStream<T> stream, long maxBufferSize) {
-    return new FlowableReadStream<>(stream, maxBufferSize, Function.identity());
+    return RxJavaPlugins.onAssembly(new FlowableReadStream<>(stream, maxBufferSize, Function.identity()));
   }
 
   public static <T> FlowableTransformer<Buffer, T> unmarshaller(Class<T> mappedType) {

--- a/rx-java2-codegen/src/main/java/io/vertx/reactivex/ObservableHelper.java
+++ b/rx-java2-codegen/src/main/java/io/vertx/reactivex/ObservableHelper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.reactivex.impl.ObservableReadStream;
@@ -37,14 +38,14 @@ public class ObservableHelper {
    * @return the adapted observable
    */
   public static <T> Observable<T> toObservable(ReadStream<T> stream) {
-    return new ObservableReadStream<T, T>(stream, Function.identity());
+    return RxJavaPlugins.onAssembly(new ObservableReadStream<T, T>(stream, Function.identity()));
   }
 
   /**
    * Like {@link #toObservable(ReadStream)} but with a {@code mapping} function
    */
   public static <T, U> Observable<U> toObservable(ReadStream<T> stream, Function<T, U> mapping) {
-    return new ObservableReadStream<>(stream, mapping);
+    return RxJavaPlugins.onAssembly(new ObservableReadStream<>(stream, mapping));
   }
 
   public static <T> ObservableTransformer<Buffer, T> unmarshaller(Class<T> mappedType) {

--- a/rx-java2/src/main/java/io/vertx/reactivex/core/RxHelper.java
+++ b/rx-java2/src/main/java/io/vertx/reactivex/core/RxHelper.java
@@ -2,6 +2,7 @@ package io.vertx.reactivex.core;
 
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Verticle;
 import io.vertx.reactivex.impl.AsyncResultSingle;
@@ -57,7 +58,7 @@ public class RxHelper {
    * @return the response observable
    */
   public static Single<String> deployVerticle(Vertx vertx, Verticle verticle, DeploymentOptions options) {
-    return new AsyncResultSingle<>(handler -> vertx.getDelegate().deployVerticle(verticle, options, handler));
+    return RxJavaPlugins.onAssembly(new AsyncResultSingle<>(handler -> vertx.getDelegate().deployVerticle(verticle, options, handler)));
   }
 
   /**


### PR DESCRIPTION
I noticed work I've done on RxJava tracing didn't work here due to
skipped assembly hooks. Whenever custom Observable type is instantiated,
it should go through `RxJavaPlugins.onAssembly()`

See https://github.com/square/retrofit/pull/2721

Note: this doesn't do this for rx types new'ed via codegen, as I don't
know how. While this change fixes my immediate issue, likely we'll want
to adjust something to ensure codegen either doesn't new up rx types
directly (ex more use of helpers, even for single and maybe), or that
the codegen does the `onAssembly` hook.