### PR TITLE
rx-gen module can't be used in OSGI environment - fixes #172

### DIFF
--- a/rx-gen/pom.xml
+++ b/rx-gen/pom.xml
@@ -16,6 +16,14 @@
   <name>Vert.x Rx Code Generator</name>
 
   <properties>
+    <!-- The path to the assembly jar descriptor -->
+    <rxgen.descriptor>${basedir}/src/main/assembly/artifact.xml</rxgen.descriptor>
+    <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
+    <lang>java</lang>
+    <!-- There is an issue with source plugin because we don't get the generated sources
+         because of BSC plugin, also the source is messy because we keep a version of vert.x core
+         so better use the assembly plugin instead -->
+    <source.skip>true</source.skip>
   </properties>
 
   <dependencies>
@@ -40,5 +48,61 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+              io.vertx.codegen,\
+              io.vertx.codegen.annotations,\
+              io.vertx.codegen.doc,\
+              io.vertx.codegen.type,\
+              javax.lang.model.element,\
+              *;resolution:=optional
+          Export-Package: \
+              io.vertx.lang.rx*
+          ]]></bnd>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <attach>true</attach>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>${rxgen.descriptor}</descriptor>
+              </descriptors>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+
+    </plugins>
+  </build>
 
 </project>

--- a/rx-gen/src/main/asciidoc/vertx-rx/java/index.adoc
+++ b/rx-gen/src/main/asciidoc/vertx-rx/java/index.adoc
@@ -1,0 +1,2 @@
+= Common generator API for RxJava/RxJava2
+:toc: left

--- a/rx-gen/src/main/assembly/artifact.xml
+++ b/rx-gen/src/main/assembly/artifact.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
+  <id>artifact</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>io/vertx/lang/rx/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/rx-java/pom.xml
+++ b/rx-java/pom.xml
@@ -30,6 +30,11 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+
     <!-- Stack dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>
@@ -324,6 +329,7 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java-gen</artifactId>
       <version>3.6.1-SNAPSHOT</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -660,6 +666,9 @@
               io.vertx.core.spi.logging,\
               io.vertx.core.spi.metrics,\
               io.vertx.core.streams,\
+              rx,\
+              rx.functions,\
+              rx.plugins,\
               *;resolution:=optional
           Export-Package: \
               io.vertx.rxjava*,\

--- a/rx-java2/pom.xml
+++ b/rx-java2/pom.xml
@@ -29,6 +29,15 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+    </dependency>
+
     <!-- Stack dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>
@@ -323,6 +332,7 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java2-gen</artifactId>
       <version>3.6.1-SNAPSHOT</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
@@ -445,6 +455,11 @@
               io.vertx.core.spi.logging,\
               io.vertx.core.spi.metrics,\
               io.vertx.core.streams,\
+              io.reactivex,\
+              io.reactivex.disposables,\
+              io.reactivex.functions,\
+              io.reactivex.internal.subscriptions,\
+              io.reactivex.plugins,\
               *;resolution:=optional
           Export-Package: \
               io.vertx.reactivex*,\


### PR DESCRIPTION
See comment [link](https://github.com/vert-x3/vertx-rx/issues/172#issuecomment-445031819) for details
- made a OSGI bundle from rx-gen module
- added explicit imports for Import-Package in rx-java/rx-java2 modules
- changed rx-java-gen and rx-java2-gen dependencies scope (do we really need them in runtime?)
