### PR TITLE
WriteStream adapter callbacks

### DIFF
--- a/rx-gen/src/test/java/io/vertx/lang/rx/test/FakeWriteStream.java
+++ b/rx-gen/src/test/java/io/vertx/lang/rx/test/FakeWriteStream.java
@@ -90,7 +90,7 @@ public class FakeWriteStream implements WriteStream<Integer> {
 
   @Override
   public void end(Handler<AsyncResult<Void>> handler) {
-    throw new UnsupportedOperationException();
+    end().setHandler(handler);
   }
 
   @Override

--- a/rx-java-gen/src/main/java/io/vertx/rx/java/WriteStreamSubscriber.java
+++ b/rx-java-gen/src/main/java/io/vertx/rx/java/WriteStreamSubscriber.java
@@ -42,7 +42,10 @@ public abstract class WriteStreamSubscriber<R> extends Subscriber<R> {
    * The underlying {@link io.vertx.core.streams.WriteStream#end()} method is invoked <strong>before</strong> the given {@code handler}.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated because the {@code handler} may be called while there are outstanding writes in the underlying {@link io.vertx.core.streams.WriteStream}.
+   * Use {@link #onWriteStreamEnd(Action0)} instead.
    */
+  @Deprecated
   public abstract WriteStreamSubscriber<R> onComplete(Action0 handler);
 
   /**
@@ -53,4 +56,18 @@ public abstract class WriteStreamSubscriber<R> extends Subscriber<R> {
    * @return a reference to this, so the API can be used fluently
    */
   public abstract WriteStreamSubscriber<R> onWriteStreamError(Action1<Throwable> handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends successfully.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public abstract WriteStreamSubscriber<R> onWriteStreamEnd(Action0 handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends with an error.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public abstract WriteStreamSubscriber<R> onWriteStreamEndError(Action1<Throwable> handler);
 }

--- a/rx-java-gen/src/test/java/io/vertx/rx/java/test/WriteStreamSubscriberTest.java
+++ b/rx-java-gen/src/test/java/io/vertx/rx/java/test/WriteStreamSubscriberTest.java
@@ -67,7 +67,7 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
   private void testObservableToWriteStream(Scheduler scheduler) throws Exception {
     disableThreadChecks();
     FakeWriteStream writeStream = new FakeWriteStream(vertx);
-    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onComplete(this::complete);
+    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onWriteStreamEnd(this::complete);
     int count = 10000;
     Observable.range(0, count)
       .observeOn(scheduler)

--- a/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
+++ b/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
@@ -115,9 +115,10 @@ CAUTION: The adapter sets the {@link io.vertx.rxjava.core.streams.WriteStream} `
 
 The {@link io.vertx.rx.java.WriteStreamSubscriber} adapter is able to invoke callbacks when:
 
-* the `Observable` completes, or
 * the `Observable` terminates with an error, or
-* the {@link io.vertx.rxjava.core.streams.WriteStream} fails (e.g. HTTP connection is closed or filesystem is full)
+* the {@link io.vertx.rxjava.core.streams.WriteStream} fails (e.g. HTTP connection is closed or filesystem is full), or
+* the {@link io.vertx.reactivex.core.streams.WriteStream} ends (i.e. all writes done and file is closed), or
+* the {@link io.vertx.reactivex.core.streams.WriteStream} ends with an error (i.e. all writes done and an error occured when closing the file)
 
 This allows for a more robust program design, as well as scheduling other tasks after the stream has been handled:
 

--- a/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
+++ b/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
@@ -117,8 +117,8 @@ The {@link io.vertx.rx.java.WriteStreamSubscriber} adapter is able to invoke cal
 
 * the `Observable` terminates with an error, or
 * the {@link io.vertx.rxjava.core.streams.WriteStream} fails (e.g. HTTP connection is closed or filesystem is full), or
-* the {@link io.vertx.reactivex.core.streams.WriteStream} ends (i.e. all writes done and file is closed), or
-* the {@link io.vertx.reactivex.core.streams.WriteStream} ends with an error (i.e. all writes done and an error occured when closing the file)
+* the {@link io.vertx.rxjava.core.streams.WriteStream} ends (i.e. all writes done and file is closed), or
+* the {@link io.vertx.rxjava.core.streams.WriteStream} ends with an error (i.e. all writes done and an error occured when closing the file)
 
 This allows for a more robust program design, as well as scheduling other tasks after the stream has been handled:
 

--- a/rx-java/src/main/java/examples/RxifiedExamples.java
+++ b/rx-java/src/main/java/examples/RxifiedExamples.java
@@ -378,7 +378,7 @@ public class RxifiedExamples {
       // log error
     });
 
-    subscriber.onComplete(() -> {
+    subscriber.onWriteStreamEnd(() -> {
       // log end of transaction to audit system...
     });
 

--- a/rx-java/src/test/java/io/vertx/it/AsyncFileTest.java
+++ b/rx-java/src/test/java/io/vertx/it/AsyncFileTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.it;
+
+import io.vertx.core.file.OpenOptions;
+import io.vertx.rxjava.core.Vertx;
+import io.vertx.rxjava.core.buffer.Buffer;
+import io.vertx.rxjava.core.file.AsyncFile;
+import io.vertx.test.core.Repeat;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+import rx.Completable;
+import rx.Observable;
+
+import java.io.File;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Thomas Segismont
+ */
+public class AsyncFileTest extends VertxTestBase {
+
+  private Vertx vertx;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    vertx = new Vertx(super.vertx);
+  }
+
+  @Test
+  @Repeat(times = 100)
+  public void observableToAsyncFile() throws Exception {
+    sourceToAsyncFile((flow, asyncFile) -> Completable.create(emitter ->
+      flow.subscribe(asyncFile.toSubscriber().onWriteStreamEnd(emitter::onCompleted))
+    ));
+  }
+
+  private void sourceToAsyncFile(BiFunction<Observable<Buffer>, AsyncFile, Completable> func) throws Exception {
+    File file = TestUtils.tmpFile("txt");
+    assertTrue(!file.exists() || file.delete());
+
+    List<Byte> bytes = IntStream.range(0, 128 * 1024).boxed()
+      .map(step -> (byte) TestUtils.randomChar())
+      .collect(toList());
+
+    Observable<Buffer> flow = Observable.from(bytes).buffer(256)
+      .map(ba -> {
+        Buffer buffer = Buffer.buffer();
+        ba.forEach(buffer::appendByte);
+        return buffer;
+      });
+
+    Completable writeToFile = vertx.fileSystem().rxOpen(file.toString(), new OpenOptions().setWrite(true))
+      .flatMapCompletable(asyncFile -> func.apply(flow, asyncFile));
+
+    writeToFile.andThen(vertx.fileSystem().rxReadFile(file.toString()))
+      .test()
+      .awaitTerminalEvent()
+      .assertValue(bytes.stream().collect(Buffer::buffer, Buffer::appendByte, Buffer::appendBuffer));
+  }
+}

--- a/rx-java2-gen/src/main/java/io/vertx/reactivex/WriteStreamObserver.java
+++ b/rx-java2-gen/src/main/java/io/vertx/reactivex/WriteStreamObserver.java
@@ -42,7 +42,10 @@ public interface WriteStreamObserver<R> extends Observer<R> {
    * The underlying {@link io.vertx.core.streams.WriteStream#end()} method is invoked <strong>before</strong> the given {@code handler}.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated because the {@code handler} may be called while there are outstanding writes in the underlying {@link io.vertx.core.streams.WriteStream}.
+   * Use {@link #onWriteStreamEnd(Action)} instead.
    */
+  @Deprecated
   WriteStreamObserver<R> onComplete(Action handler);
 
   /**
@@ -53,4 +56,18 @@ public interface WriteStreamObserver<R> extends Observer<R> {
    * @return a reference to this, so the API can be used fluently
    */
   WriteStreamObserver<R> onWriteStreamError(Consumer<? super Throwable> handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends successfully.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  WriteStreamObserver<R> onWriteStreamEnd(Action handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends with an error.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  WriteStreamObserver<R> onWriteStreamEndError(Consumer<? super Throwable> handler);
 }

--- a/rx-java2-gen/src/main/java/io/vertx/reactivex/WriteStreamSubscriber.java
+++ b/rx-java2-gen/src/main/java/io/vertx/reactivex/WriteStreamSubscriber.java
@@ -42,7 +42,10 @@ public interface WriteStreamSubscriber<R> extends FlowableSubscriber<R> {
    * The underlying {@link io.vertx.core.streams.WriteStream#end()} method is invoked <strong>before</strong> the given {@code handler}.
    *
    * @return a reference to this, so the API can be used fluently
+   * @deprecated because the {@code handler} may be called while there are outstanding writes in the underlying {@link io.vertx.core.streams.WriteStream}.
+   * Use {@link #onWriteStreamEnd(Action)} instead.
    */
+  @Deprecated
   WriteStreamSubscriber<R> onComplete(Action handler);
 
   /**
@@ -53,4 +56,18 @@ public interface WriteStreamSubscriber<R> extends FlowableSubscriber<R> {
    * @return a reference to this, so the API can be used fluently
    */
   WriteStreamSubscriber<R> onWriteStreamError(Consumer<? super Throwable> handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends successfully.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  WriteStreamSubscriber<R> onWriteStreamEnd(Action handler);
+
+  /**
+   * Sets the handler to invoke when the adapted {@link io.vertx.core.streams.WriteStream} ends with an error.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  WriteStreamSubscriber<R> onWriteStreamEndError(Consumer<? super Throwable> handler);
 }

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/WriteStreamObserverTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/WriteStreamObserverTest.java
@@ -58,7 +58,7 @@ public class WriteStreamObserverTest extends VertxTestBase {
   @Test
   public void testObservableToWriteStream() throws Exception {
     FakeWriteStream writeStream = new FakeWriteStream(vertx);
-    Observer<Integer> observer = RxHelper.toObserver(writeStream).onComplete(this::complete);
+    Observer<Integer> observer = RxHelper.toObserver(writeStream).onWriteStreamEnd(this::complete);
     int count = 10000;
     Observable.range(0, count)
       .observeOn(RxHelper.scheduler(vertx))
@@ -77,7 +77,7 @@ public class WriteStreamObserverTest extends VertxTestBase {
       assertThat(throwable, is(instanceOf(ProtocolViolationException.class)));
       complete();
     });
-    Observer<Integer> observer = RxHelper.toObserver(new FakeWriteStream(vertx)).onComplete(this::complete);
+    Observer<Integer> observer = RxHelper.toObserver(new FakeWriteStream(vertx)).onWriteStreamEnd(this::complete);
     Observable.range(0, 100)
       .observeOn(RxHelper.scheduler(vertx))
       .subscribeOn(RxHelper.scheduler(vertx))
@@ -150,7 +150,7 @@ public class WriteStreamObserverTest extends VertxTestBase {
   }
 
   @Test
-  public void testOnCompleteThrowsException() throws Exception {
+  public void testOnWriteStreamEndThrowsException() throws Exception {
     RuntimeException expected = new RuntimeException();
     RxJavaPlugins.setErrorHandler(throwable -> {
       assertThat(throwable, is(instanceOf(UndeliverableException.class)));
@@ -158,7 +158,7 @@ public class WriteStreamObserverTest extends VertxTestBase {
       complete();
     });
     FakeWriteStream writeStream = new FakeWriteStream(vertx);
-    Observer<Integer> observer = RxHelper.toObserver(writeStream).onComplete(() -> {
+    Observer<Integer> observer = RxHelper.toObserver(writeStream).onWriteStreamEnd(() -> {
       throw expected;
     });
     Observable.just(0)

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/WriteStreamSubscriberTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/WriteStreamSubscriberTest.java
@@ -75,7 +75,7 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
 
   private void testFlowableToWriteStream(Scheduler scheduler) throws Exception {
     FakeWriteStream writeStream = new FakeWriteStream(vertx);
-    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onComplete(this::complete);
+    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onWriteStreamEnd(this::complete);
     int count = 10000;
     Flowable.range(0, count)
       .observeOn(RxHelper.scheduler(vertx))
@@ -94,7 +94,7 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
       assertThat(throwable, is(instanceOf(ProtocolViolationException.class)));
       complete();
     });
-    Subscriber<Integer> subscriber = RxHelper.toSubscriber(new FakeWriteStream(vertx)).onComplete(this::complete);
+    Subscriber<Integer> subscriber = RxHelper.toSubscriber(new FakeWriteStream(vertx)).onWriteStreamEnd(this::complete);
     Flowable.range(0, 100)
       .observeOn(RxHelper.scheduler(vertx))
       .subscribeOn(RxHelper.scheduler(vertx))
@@ -168,7 +168,7 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
   }
 
   @Test
-  public void testOnCompleteThrowsException() throws Exception {
+  public void testOnWriteStreamEndThrowsException() throws Exception {
     RuntimeException expected = new RuntimeException();
     RxJavaPlugins.setErrorHandler(throwable -> {
       assertThat(throwable, is(instanceOf(UndeliverableException.class)));
@@ -176,7 +176,7 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
       complete();
     });
     FakeWriteStream writeStream = new FakeWriteStream(vertx);
-    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onComplete(() -> {
+    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onWriteStreamEnd(() -> {
       throw expected;
     });
     Flowable.just(0)

--- a/rx-java2/src/main/asciidoc/vertx-rx/java2/index.adoc
+++ b/rx-java2/src/main/asciidoc/vertx-rx/java2/index.adoc
@@ -126,9 +126,10 @@ CAUTION: The adapter sets the {@link io.vertx.reactivex.core.streams.WriteStream
 
 The {@link io.vertx.reactivex.WriteStreamSubscriber} adapter is able to invoke callbacks when:
 
-* the `Flowable` completes, or
 * the `Flowable` terminates with an error, or
-* the {@link io.vertx.reactivex.core.streams.WriteStream} fails (e.g. HTTP connection is closed or filesystem is full)
+* the {@link io.vertx.reactivex.core.streams.WriteStream} fails (e.g. HTTP connection is closed or filesystem is full), or
+* the {@link io.vertx.reactivex.core.streams.WriteStream} ends (i.e. all writes done and file is closed), or
+* the {@link io.vertx.reactivex.core.streams.WriteStream} ends with an error (i.e. all writes done and an error occured when closing the file)
 
 This allows for a more robust program design, as well as scheduling other tasks after the stream has been handled:
 

--- a/rx-java2/src/main/java/examples/RxifiedExamples.java
+++ b/rx-java2/src/main/java/examples/RxifiedExamples.java
@@ -410,7 +410,7 @@ public class RxifiedExamples {
       // log error
     });
 
-    subscriber.onComplete(() -> {
+    subscriber.onWriteStreamEnd(() -> {
       // log end of transaction to audit system...
     });
 

--- a/rx-java2/src/test/java/io/vertx/it/AsyncFileTest.java
+++ b/rx-java2/src/test/java/io/vertx/it/AsyncFileTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.it;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.file.AsyncFile;
+import io.vertx.test.core.Repeat;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Thomas Segismont
+ */
+public class AsyncFileTest extends VertxTestBase {
+
+  private Vertx vertx;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    vertx = new Vertx(super.vertx);
+  }
+
+  @Test
+  @Repeat(times = 100)
+  public void flowableToAsyncFile() throws Exception {
+    sourceToAsyncFile((flow, asyncFile) -> Completable.create(emitter ->
+      flow.subscribe(asyncFile.toSubscriber().onWriteStreamEnd(emitter::onComplete))
+    ));
+  }
+
+  @Test
+  @Repeat(times = 100)
+  public void observableToAsyncFile() throws Exception {
+    sourceToAsyncFile((flow, asyncFile) -> Completable.create(emitter ->
+      flow.toObservable().subscribe(asyncFile.toObserver().onWriteStreamEnd(emitter::onComplete))
+    ));
+  }
+
+  private void sourceToAsyncFile(BiFunction<Flowable<Buffer>, AsyncFile, Completable> func) throws Exception {
+    File file = TestUtils.tmpFile("txt");
+    assertTrue(!file.exists() || file.delete());
+
+    List<Byte> bytes = IntStream.range(0, 128 * 1024).boxed()
+      .map(step -> (byte) TestUtils.randomChar())
+      .collect(toList());
+
+    Flowable<Buffer> flow = Flowable.fromIterable(bytes).buffer(256, () -> new ArrayList<>(256))
+      .map(ba -> {
+        Buffer buffer = Buffer.buffer();
+        ba.forEach(buffer::appendByte);
+        return buffer;
+      });
+
+    Completable writeToFile = vertx.fileSystem().rxOpen(file.toString(), new OpenOptions().setWrite(true))
+      .flatMapCompletable(asyncFile -> func.apply(flow, asyncFile));
+
+    writeToFile.andThen(vertx.fileSystem().rxReadFile(file.toString()))
+      .test()
+      .await()
+      .assertValue(bytes.stream().<Buffer>collect(Buffer::buffer, Buffer::appendByte, Buffer::appendBuffer));
+  }
+}


### PR DESCRIPTION
Closes #218 

The current onComplete callback is tricky because the underlying WriteStream might outstanding writes after the end() method returns.

In this PR, new callbacks are added to handle end(Handler) events.

The onComplete callbacks is deprecated for 3.8.6 and will be removed in 4.0.