### PR TITLE
JUnit5 providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <module>rx-java2-gen</module>
     <module>rx-java</module>
     <module>rx-java2</module>
+    <module>rx-junit5-providers</module>
   </modules>
 
   <properties>

--- a/rx-junit5-providers/pom.xml
+++ b/rx-junit5-providers/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/rx-junit5-providers/pom.xml
+++ b/rx-junit5-providers/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>vertx-rx</artifactId>
+    <groupId>io.vertx</groupId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>rx-junit5-providers</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>vertx-junit5-rx-java</module>
+    <module>vertx-junit5-rx-java2</module>
+  </modules>
+
+  <properties>
+    <assertj-core.version>3.14.0</assertj-core.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <junit-platform-launcher.version>1.6.0</junit-platform-launcher.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${junit-platform-launcher.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/rx-junit5-providers/vertx-junit5-rx-java/pom.xml
+++ b/rx-junit5-providers/vertx-junit5-rx-java/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>rx-junit5-providers</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-junit5-rx-java</artifactId>
+  <name>Vert.x JUnit 5 RxJava support</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/rx-junit5-providers/vertx-junit5-rx-java/src/main/java/io/vertx/junit5/rxjava/VertxParameterProvider.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java/src/main/java/io/vertx/junit5/rxjava/VertxParameterProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5.rxjava;
+
+import io.vertx.core.VertxException;
+import io.vertx.junit5.ParameterClosingConsumer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxExtensionParameterProvider;
+import io.vertx.rxjava.core.Vertx;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+import java.util.concurrent.TimeoutException;
+
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_DURATION;
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_UNIT;
+
+/**
+ * RxJava Vertx context parameter provider.
+ *
+ * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
+ */
+public class VertxParameterProvider implements VertxExtensionParameterProvider<Vertx> {
+  @Override
+  public Class<Vertx> type() {
+    return Vertx.class;
+  }
+
+  @Override
+  public String key() {
+    return VertxExtension.VERTX_INSTANCE_KEY;
+  }
+
+  @Override
+  public Vertx newInstance(ExtensionContext extensionContext, ParameterContext parameterContext) {
+    return Vertx.vertx();
+  }
+
+  @Override
+  public ParameterClosingConsumer<Vertx> parameterClosingConsumer() {
+    return vertx -> {
+      try {
+        if (!vertx.rxClose().toCompletable().await(DEFAULT_TIMEOUT_DURATION, DEFAULT_TIMEOUT_UNIT)) {
+          throw new TimeoutException("Closing the Vertx context timed out");
+        }
+      } catch (Throwable err) {
+        if (err instanceof RuntimeException) {
+          throw new VertxException(err.getCause());
+        } else if (err instanceof Exception) {
+          throw err;
+        } else {
+          throw new VertxException(err);
+        }
+      }
+    };
+  }
+}

--- a/rx-junit5-providers/vertx-junit5-rx-java/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
+++ b/rx-junit5-providers/vertx-junit5-rx-java/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
@@ -1,0 +1,1 @@
+io.vertx.junit5.rxjava.VertxParameterProvider

--- a/rx-junit5-providers/vertx-junit5-rx-java/src/test/java/io/vertx/junit5/rxjava/RxJava1Test.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java/src/test/java/io/vertx/junit5/rxjava/RxJava1Test.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5.rxjava;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava.core.AbstractVerticle;
+import io.vertx.rxjava.core.RxHelper;
+import io.vertx.rxjava.core.Vertx;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+@DisplayName("Test the RxJava 1 support")
+class RxJava1Test {
+
+  @Test
+  @DisplayName("Check the injection of a /io.vertx.rxjava.core.Vertx/ instance")
+  void check_injection(Vertx vertx, VertxTestContext testContext) {
+    testContext.verify(() -> {
+      assertThat(vertx).isNotNull();
+      testContext.completeNow();
+    });
+  }
+
+  @Test
+  @DisplayName("Check the deployment and interaction of a Rx1 verticle")
+  void check_deployment_and_message_send(Vertx vertx, VertxTestContext testContext) {
+    RxHelper
+      .deployVerticle(vertx, new RxVerticle())
+      .toSingle()
+      .flatMap(id -> vertx.eventBus().rxRequest("check", "Ok?"))
+      .subscribe(
+        message -> testContext.verify(() -> {
+          assertThat(message.body()).isEqualTo("Check!");
+          testContext.completeNow();
+        }),
+        testContext::failNow);
+  }
+
+  static class RxVerticle extends AbstractVerticle {
+
+    @Override
+    public void start() throws Exception {
+      vertx.eventBus().consumer("check", message -> message.reply("Check!"));
+    }
+  }
+}

--- a/rx-junit5-providers/vertx-junit5-rx-java2/pom.xml
+++ b/rx-junit5-providers/vertx-junit5-rx-java2/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>rx-junit5-providers</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-junit5-rx-java2</artifactId>
+  <name>Vert.x JUnit 5 RxJava2 support</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java2</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/rx-junit5-providers/vertx-junit5-rx-java2/src/main/java/io/vertx/junit5/rxjava2/VertxParameterProvider.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java2/src/main/java/io/vertx/junit5/rxjava2/VertxParameterProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5.rxjava2;
+
+import io.vertx.core.VertxException;
+import io.vertx.junit5.ParameterClosingConsumer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxExtensionParameterProvider;
+import io.vertx.reactivex.core.Vertx;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+import java.util.concurrent.TimeoutException;
+
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_DURATION;
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_UNIT;
+
+/**
+ * RxJava 2 Vertx parameter provider.
+ *
+ * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
+ */
+public class VertxParameterProvider implements VertxExtensionParameterProvider<Vertx> {
+  @Override
+  public Class<Vertx> type() {
+    return Vertx.class;
+  }
+
+  @Override
+  public String key() {
+    return VertxExtension.VERTX_INSTANCE_KEY;
+  }
+
+  @Override
+  public Vertx newInstance(ExtensionContext extensionContext, ParameterContext parameterContext) {
+    return Vertx.vertx();
+  }
+
+  @Override
+  public ParameterClosingConsumer<Vertx> parameterClosingConsumer() {
+    return vertx -> {
+      try {
+        if (!vertx.rxClose().blockingAwait(DEFAULT_TIMEOUT_DURATION, DEFAULT_TIMEOUT_UNIT)) {
+          throw new TimeoutException("Closing the Vertx context timed out");
+        }
+      } catch (Throwable err) {
+        if (err instanceof RuntimeException) {
+          throw new VertxException(err.getCause());
+        } else if (err instanceof Exception) {
+          throw err;
+        } else {
+          throw new VertxException(err);
+        }
+      }
+    };
+  }
+}

--- a/rx-junit5-providers/vertx-junit5-rx-java2/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
+++ b/rx-junit5-providers/vertx-junit5-rx-java2/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
@@ -1,0 +1,1 @@
+io.vertx.junit5.rxjava2.VertxParameterProvider

--- a/rx-junit5-providers/vertx-junit5-rx-java2/src/test/java/io/vertx/junit5/rxjava2/RxJava2Test.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java2/src/test/java/io/vertx/junit5/rxjava2/RxJava2Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.junit5.rxjava2;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.RxHelper;
+import io.vertx.reactivex.core.Vertx;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+@DisplayName("Test the RxJava 2 support")
+class RxJava2Test {
+
+  @Test
+  @DisplayName("Check the injection of a /io.vertx.reactivex.core.Vertx/ instance")
+  void check_injection(Vertx vertx, VertxTestContext testContext) {
+    testContext.verify(() -> {
+      assertThat(vertx).isNotNull();
+      testContext.completeNow();
+    });
+  }
+
+  @Test
+  @DisplayName("Check the deployment and interaction of a Rx1 verticle")
+  void check_deployment_and_message_send(Vertx vertx, VertxTestContext testContext) {
+    RxHelper
+      .deployVerticle(vertx, new RxVerticle())
+      .flatMap(id -> vertx.eventBus().rxRequest("check", "Ok?"))
+      .subscribe(
+        message -> testContext.verify(() -> {
+          assertThat(message.body()).isEqualTo("Check!");
+          testContext.completeNow();
+        }),
+        testContext::failNow);
+  }
+
+  static class RxVerticle extends AbstractVerticle {
+
+    @Override
+    public void start() throws Exception {
+      vertx.eventBus().consumer("check", message -> message.reply("Check!"));
+    }
+  }
+}


### PR DESCRIPTION
This transplants the code from `vertx-junit5-extensions` with the RxJava 1 + 2 bindings for `Vertx` objects to be injected in tests.

Note that the branch is based on a branch that does not passes tests for `vertx-rx-java`, see #221 