### PR TITLE
Bug reproducer where having 2 types with the same name causes an ambiguous import

### DIFF
--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DuplicatesInterface.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DuplicatesInterface.java
@@ -1,0 +1,21 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.extra.duplicates.SomeRandomType;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+@VertxGen
+public interface DuplicatesInterface {
+
+  static DuplicatesInterface create() {
+    return new DuplicatesInterfaceImpl();
+  }
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void abc(SomeRandomType arg, Handler<AsyncResult<SomeRandomType>> handler);
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void def(io.vertx.codegen.extra.duplicates.nested.SomeRandomType arg, Handler<AsyncResult<io.vertx.codegen.extra.duplicates.nested.SomeRandomType>> handler);
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DuplicatesInterfaceImpl.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DuplicatesInterfaceImpl.java
@@ -1,0 +1,18 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.extra.duplicates.SomeRandomType;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class DuplicatesInterfaceImpl implements DuplicatesInterface {
+  @Override
+  public void abc(SomeRandomType arg, Handler<AsyncResult<SomeRandomType>> handler) {
+    handler.handle(Future.succeededFuture(arg));
+  }
+
+  @Override
+  public void def(io.vertx.codegen.extra.duplicates.nested.SomeRandomType arg, Handler<AsyncResult<io.vertx.codegen.extra.duplicates.nested.SomeRandomType>> handler) {
+    handler.handle(Future.succeededFuture(arg));
+  }
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/duplicates/SomeRandomType.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/duplicates/SomeRandomType.java
@@ -1,0 +1,4 @@
+package io.vertx.codegen.extra.duplicates;
+
+public class SomeRandomType {
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/duplicates/nested/SomeRandomType.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/duplicates/nested/SomeRandomType.java
@@ -1,0 +1,4 @@
+package io.vertx.codegen.extra.duplicates.nested;
+
+public class SomeRandomType {
+}


### PR DESCRIPTION
Bug reproducer where having 2 types with the same name causes an ambiguous import
