### PR TITLE
Rx overloaded methods improvements

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -627,7 +627,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     return genTypeName(type, false);
   }
 
-  protected final String genTypeName(TypeInfo type, boolean translate) {
+  protected String genTypeName(TypeInfo type, boolean translate) {
     if (type.isParameterized()) {
       ParameterizedTypeInfo pt = (ParameterizedTypeInfo) type;
       return genTypeName(pt.getRaw(), translate) + pt.getArgs().stream().map(a -> genTypeName(a, translate)).collect(joining(", ", "<", ">"));
@@ -924,7 +924,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     return sb.toString();
   }
 
-  private String genConvReturn(TypeInfo type, MethodInfo method, String expr) {
+  protected String genConvReturn(TypeInfo type, MethodInfo method, String expr) {
     ClassKind kind = type.getKind();
     if (kind == OBJECT) {
       if (type.isVariable()) {

--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -757,28 +757,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
         ret.append(", ");
       }
       TypeInfo type = param.getType();
-      if (type.isParameterized() && type.getRaw().getName().equals("rx.Observable")) {
-        String adapterFunction;
-        ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
-
-        if (parameterizedType.getArg(0).isVariable()) {
-          adapterFunction = "Function.identity()";
-        } else {
-          adapterFunction = "obj -> (" + parameterizedType.getArg(0).getRaw().getName() + ")obj.getDelegate()";
-        }
-        ret.append("io.vertx.rx.java.ReadStreamSubscriber.asReadStream(").append(param.getName()).append(",").append(adapterFunction).append(").resume()");
-      } else if (type.isParameterized() && (type.getRaw().getName().equals("io.reactivex.Flowable") || type.getRaw().getName().equals("io.reactivex.Observable"))) {
-        String adapterFunction;
-        ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
-        if (parameterizedType.getArg(0).isVariable()) {
-          adapterFunction = "Function.identity()";
-        } else {
-          adapterFunction = "obj -> (" + parameterizedType.getArg(0).getRaw().getName() + ")obj.getDelegate()";
-        }
-        ret.append("io.vertx.reactivex.impl.ReadStreamSubscriber.asReadStream(").append(param.getName()).append(",").append(adapterFunction).append(").resume()");
-      } else {
-        ret.append(genConvParam(type, method, param.getName()));
-      }
+      ret.append(genConvParam(type, method, param.getName()));
       index = index + 1;
     }
     ret.append(")");
@@ -810,7 +789,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     return false;
   }
 
-  private String genConvParam(TypeInfo type, MethodInfo method, String expr) {
+  protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
     ClassKind kind = type.getKind();
     if (isSameType(type, method)) {
       return expr;

--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -863,7 +863,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
       if (typeArg != null) {
         if (typeArg.isClassType()) {
           return "TypeArg.of(" + typeArg.getParam().getName() + ")";
-        } else {
+        } else if (!method.isStaticMethod()) {
           return typeArg.getParam().getName() + ".__typeArg_" + typeArg.getIndex();
         }
       }

--- a/rx-java-gen/src/main/java/io/vertx/lang/rxjava/RxJavaGenerator.java
+++ b/rx-java-gen/src/main/java/io/vertx/lang/rxjava/RxJavaGenerator.java
@@ -224,4 +224,20 @@ class RxJavaGenerator extends AbstractRxGenerator {
     writer.println("> toObservable();");
     writer.println();
   }
+
+  @Override
+  protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
+    if (type.isParameterized() && type.getRaw().getName().equals("rx.Observable")) {
+      String adapterFunction;
+      ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
+
+      if (parameterizedType.getArg(0).isVariable()) {
+        adapterFunction = "Function.identity()";
+      } else {
+        adapterFunction = "obj -> (" + parameterizedType.getArg(0).getRaw().getName() + ")obj.getDelegate()";
+      }
+      return "io.vertx.rx.java.ReadStreamSubscriber.asReadStream(" + expr + "," + adapterFunction + ").resume()";
+    }
+    return super.genConvParam(type, method, expr);
+  }
 }

--- a/rx-java2-gen/pom.xml
+++ b/rx-java2-gen/pom.xml
@@ -123,6 +123,59 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.bsc.maven</groupId>
+        <artifactId>maven-processor-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <systemProperties>
+            <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+            <mvel2.disable.jit>true</mvel2.disable.jit>
+          </systemProperties>
+        </configuration>
+        <executions>
+          <!-- Run the annotation processor on java sources and generate the API -->
+          <execution>
+            <id>generate-api</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/sources/java</sourceDirectory>
+              <processors>
+                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <codegen.output>${project.basedir}/src/main</codegen.output>
+              </optionMap>
+              <excludes>
+                <exclude>examples/**/*.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+
+          <!-- Run the annotation processor to produce test stubs -->
+          <execution>
+            <id>generate-stubs</id>
+            <goals>
+              <goal>process-test</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/stubs</sourceDirectory>
+              <processors>
+                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <codegen.output>${project.basedir}/src/test</codegen.output>
+                <codegen.generators>RxJava2</codegen.generators>
+              </optionMap>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Configure the execution of the compiler to execute the codegen processor -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -179,22 +232,6 @@
               </artifactItems>
               <outputDirectory>${project.basedir}/src/unpacked/java</outputDirectory>
               <includes>**/*.java,META-INF/vertx/json-mappers.properties</includes>
-            </configuration>
-          </execution>
-          <!-- Unpack stream vertx core source code to src/unpacked/java -->
-          <execution>
-            <id>unpack-core</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeGroupIds>io.vertx</includeGroupIds>
-              <includeArtifactIds>vertx-core</includeArtifactIds>
-              <includeTypes>jar</includeTypes>
-              <includeClassifiers>sources</includeClassifiers>
-              <outputDirectory>${basedir}/src/unpacked/java</outputDirectory>
-              <includes>io/vertx/core/streams/*.java</includes>
             </configuration>
           </execution>
         </executions>

--- a/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
+++ b/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
@@ -217,6 +217,22 @@ class RxJava2Generator extends AbstractRxGenerator {
     writer.println();
   }
 
+  @Override
+  protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
+    if (type.isParameterized() && (type.getRaw().getName().equals("io.reactivex.Flowable") || type.getRaw().getName().equals("io.reactivex.Observable"))) {
+      String adapterFunction;
+      ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
+      if (parameterizedType.getArg(0).isVariable()) {
+        adapterFunction = "Function.identity()";
+      } else {
+        adapterFunction = "obj -> (" + parameterizedType.getArg(0).getRaw().getName() + ")obj.getDelegate()";
+      }
+      return "io.vertx.reactivex.impl.ReadStreamSubscriber.asReadStream(" + expr + "," + adapterFunction + ").resume()";
+    } else {
+      return super.genConvParam(type, method, expr);
+    }
+  }
+
   private MethodInfo genFutureMethod(MethodInfo method) {
     String futMethodName = genFutureMethodName(method);
     List<ParamInfo> futParams = new ArrayList<>();

--- a/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
+++ b/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
@@ -220,14 +220,9 @@ class RxJava2Generator extends AbstractRxGenerator {
   @Override
   protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
     if (type.isParameterized() && (type.getRaw().getName().equals("io.reactivex.Flowable") || type.getRaw().getName().equals("io.reactivex.Observable"))) {
-      String adapterFunction;
       ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;
-      if (parameterizedType.getArg(0).isVariable()) {
-        adapterFunction = "Function.identity()";
-      } else {
-        adapterFunction = "obj -> (" + parameterizedType.getArg(0).getRaw().getName() + ")obj.getDelegate()";
-      }
-      return "io.vertx.reactivex.impl.ReadStreamSubscriber.asReadStream(" + expr + "," + adapterFunction + ").resume()";
+      String adapterFunction = "obj -> " + genConvParam(parameterizedType.getArg(0), method, "obj");
+      return "io.vertx.reactivex.impl.ReadStreamSubscriber.asReadStream(" + expr + ", " + adapterFunction + ").resume()";
     } else {
       return super.genConvParam(type, method, expr);
     }

--- a/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
+++ b/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
@@ -26,17 +26,7 @@ class RxJava2Generator extends AbstractRxGenerator {
   }
 
   @Override
-  protected boolean isImported(TypeInfo type) {
-    return type.getName().startsWith("io.reactivex.") || super.isImported(type);
-  }
-
-  @Override
   protected void genImports(ClassModel model, PrintWriter writer) {
-    writer.println("import io.reactivex.Observable;");
-    writer.println("import io.reactivex.Flowable;");
-    writer.println("import io.reactivex.Single;");
-    writer.println("import io.reactivex.Completable;");
-    writer.println("import io.reactivex.Maybe;");
     writer.println("import io.vertx.reactivex.RxHelper;");
     writer.println("import io.vertx.reactivex.ObservableHelper;");
     writer.println("import io.vertx.reactivex.FlowableHelper;");
@@ -50,11 +40,11 @@ class RxJava2Generator extends AbstractRxGenerator {
 
   @Override
   protected void genToObservable(TypeInfo streamType, PrintWriter writer) {
-    writer.print("  private Observable<");
+    writer.print("  private io.reactivex.Observable<");
     writer.print(genTranslatedTypeName(streamType));
     writer.println("> observable;");
 
-    writer.print("  private Flowable<");
+    writer.print("  private io.reactivex.Flowable<");
     writer.print(genTranslatedTypeName(streamType));
     writer.println("> flowable;");
 
@@ -66,6 +56,7 @@ class RxJava2Generator extends AbstractRxGenerator {
 
   private void genToXXXAble(TypeInfo streamType, String rxType, String rxName, PrintWriter writer) {
     writer.print("  public synchronized ");
+    writer.print("io.reactivex.");
     writer.print(rxType);
     writer.print("<");
     writer.print(genTranslatedTypeName(streamType));
@@ -215,12 +206,12 @@ class RxJava2Generator extends AbstractRxGenerator {
   }
 
   protected void genReadStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer){
-    writer.print("  Observable<");
+    writer.print("  io.reactivex.Observable<");
     writer.print(typeParams.get(0).getName());
     writer.println("> toObservable();");
     writer.println();
 
-    writer.print("  Flowable<");
+    writer.print("  io.reactivex.Flowable<");
     writer.print(typeParams.get(0).getName());
     writer.println("> toFlowable();");
     writer.println();

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/rxjava2/MethodWithFunction.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/rxjava2/MethodWithFunction.java
@@ -1,0 +1,39 @@
+package io.vertx.codegen.rxjava2;
+
+import io.reactivex.Single;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithFunction {
+
+  static <T, R> boolean isSucceeded(T t, Function<T, Future<R>> future) {
+    Future<R> fut = future.apply(t);
+    return fut.succeeded();
+  }
+
+  static <T, R> boolean isFailed(T t, Function<T, Future<R>> future) {
+    Future<R> fut = future.apply(t);
+    return fut.failed();
+  }
+
+  static <T, R> boolean isComplete(T t, Function<T, Future<R>> future) {
+    Future<R> fut = future.apply(t);
+    return fut.isComplete();
+  }
+
+  static <T, R> R getResult(T t, Function<T, Future<R>> future) {
+    Future<R> fut = future.apply(t);
+    return fut.result();
+  }
+
+  static <T, R> Throwable getCause(T t, Function<T, Future<R>> future) {
+    Future<R> fut = future.apply(t);
+    return fut.cause();
+  }
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/rxjava2/MethodWithFuture.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/rxjava2/MethodWithFuture.java
@@ -1,0 +1,33 @@
+package io.vertx.codegen.rxjava2;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface MethodWithFuture {
+
+  static <T> boolean isSucceeded(Future<T> future) {
+    return future.succeeded();
+  }
+
+  static <T> boolean isFailed(Future<T> future) {
+    return future.failed();
+  }
+
+  static <T> boolean isComplete(Future<T> future) {
+    return future.isComplete();
+  }
+
+  static <T> T getResult(Future<T> future) {
+    return future.result();
+  }
+
+  static <T> Throwable getCause(Future<T> future) {
+    return future.cause();
+  }
+}

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/HelperTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/HelperTest.java
@@ -29,6 +29,23 @@ import static java.util.function.Function.identity;
 public class HelperTest extends VertxTestBase {
 
   @Test
+  public void testToFutureSuccess() {
+    Single<String> promise = Single.just("foobar");
+    Future<String> future = SingleHelper.toFuture(promise);
+    assertTrue(future.succeeded());
+    assertEquals("foobar", future.result());
+  }
+
+  @Test
+  public void testToFutureFailure() {
+    Exception err = new Exception();
+    Single<String> promise = Single.error(err);
+    Future<String> future = SingleHelper.toFuture(promise);
+    assertTrue(future.failed());
+    assertEquals(err, future.cause());
+  }
+
+  @Test
   public void testToSingleObserverSuccess() {
     Promise<String> promise = Promise.promise();
     SingleObserver<String> observer = SingleHelper.toObserver(promise);

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/OverloadMethodsTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/OverloadMethodsTest.java
@@ -1,0 +1,53 @@
+package io.vertx.reactivex.test;
+
+import io.reactivex.Single;
+import io.reactivex.functions.Function;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import io.vertx.reactivex.codegen.rxjava2.MethodWithFuture;
+import io.vertx.reactivex.codegen.rxjava2.MethodWithFunction;
+
+
+public class OverloadMethodsTest extends VertxTestBase {
+
+  @Test
+  public void testSingleSuccess() {
+    Single<String> single = Single.just("foobar");
+    assertTrue(MethodWithFuture.isSucceeded(single));
+    assertEquals("foobar", MethodWithFuture.getResult(single));
+  }
+
+  @Test
+  public void testSingleFailure() {
+    Throwable error = new Throwable();
+    Single<String> single = Single.error(error);
+    assertTrue(MethodWithFuture.isFailed(single));
+    assertEquals(error, MethodWithFuture.getCause(single));
+  }
+
+  @Test
+  public void testFunctionReturningSingleSuccess() {
+    Function<String, Single<Integer>> strLen = s -> Single.just(s).map(String::length);
+    assertTrue(MethodWithFunction.isSucceeded("foobar", strLen));
+    assertEquals(6, (int)MethodWithFunction.getResult("foobar", strLen));
+  }
+
+  @Test
+  public void testFunctionReturningSingleFailure() {
+    Throwable error = new Throwable();
+    Function<String, Single<Integer>> strLen = s -> Single.<String>error(error).map(String::length);
+    assertTrue(MethodWithFunction.isFailed("foobar", strLen));
+    assertEquals(error, MethodWithFunction.getCause("foobar", strLen));
+  }
+
+  @Test
+  public void testFunctionReturningSingleFunctionFailure() {
+    Exception error = new Exception();
+    Function<String, Single<Integer>> strLen = s -> {
+      throw error;
+    };
+    assertTrue(MethodWithFunction.isFailed("foobar", strLen));
+    assertEquals(error, MethodWithFunction.getCause("foobar", strLen));
+  }
+}

--- a/rx-java2-gen/src/test/stubs/io/vertx/core/Future.java
+++ b/rx-java2-gen/src/test/stubs/io/vertx/core/Future.java
@@ -9,10 +9,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.streams;
+package io.vertx.core;
 
 import io.vertx.codegen.annotations.VertxGen;
 
 @VertxGen
-public interface Pipe<T> {
+public interface Future<T> {
 }

--- a/rx-java2-gen/src/test/stubs/io/vertx/core/streams/Pipe.java
+++ b/rx-java2-gen/src/test/stubs/io/vertx/core/streams/Pipe.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.streams;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.streams.impl.PipeImpl;
+
+@VertxGen()
+public interface Pipe<T> {
+}

--- a/rx-java2-gen/src/test/stubs/io/vertx/core/streams/ReadStream.java
+++ b/rx-java2-gen/src/test/stubs/io/vertx/core/streams/ReadStream.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.streams;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen(concrete = false)
+public interface ReadStream<T> {
+}

--- a/rx-java2-gen/src/test/stubs/io/vertx/core/streams/WriteStream.java
+++ b/rx-java2-gen/src/test/stubs/io/vertx/core/streams/WriteStream.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.streams;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen(concrete = false)
+public interface WriteStream<T> {
+}

--- a/rx-java2/src/test/java/io/vertx/it/WebClientTest.java
+++ b/rx-java2/src/test/java/io/vertx/it/WebClientTest.java
@@ -1,5 +1,6 @@
 package io.vertx.it;
 
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.vertx.core.http.HttpClientOptions;
@@ -68,7 +69,7 @@ public class WebClientTest extends VertxTestBase {
         Observable<Buffer> stream = Observable.just(Buffer.buffer("one"), Buffer.buffer("two"), Buffer.buffer("three"));
         Single<HttpResponse<Buffer>> single = client
                 .post(8080, "localhost", "/the_uri")
-                .rxSendStream(stream);
+                .rxSendStream(stream.toFlowable(BackpressureStrategy.BUFFER));
         for (int i = 0; i < times; i++) {
           single.subscribe(resp -> complete(), this::fail);
         }

--- a/rx-java2/src/test/java/io/vertx/reactivex/jdbcclient/JDBCTest.java
+++ b/rx-java2/src/test/java/io/vertx/reactivex/jdbcclient/JDBCTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.reactivex.jdbcclient;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Function;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.ext.sql.SQLClient;
+import io.vertx.reactivex.ext.sql.SQLClientHelper;
+import io.vertx.reactivex.ext.sql.SQLConnection;
+import io.vertx.reactivex.sqlclient.Row;
+import io.vertx.reactivex.sqlclient.RowSet;
+import io.vertx.reactivex.sqlclient.SqlClient;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Thomas Segismont
+ */
+public class JDBCTest extends VertxTestBase {
+
+  protected static final List<String> NAMES = Arrays.asList("John", "Paul", "Peter", "Andrew", "Peter", "Steven");
+
+  protected static final String UNIQUE_NAMES_SQL = "select distinct firstname from folks order by firstname asc";
+
+  protected static final String INSERT_FOLK_SQL = "insert into folks (firstname) values ('%s')";
+
+  private static final JsonObject config = new JsonObject()
+    .put("driver_class", "org.hsqldb.jdbcDriver")
+    .put("url", "jdbc:hsqldb:mem:test?shutdown=true");
+
+  protected JDBCPool client;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    client = JDBCPool.pool(Vertx.newInstance(vertx), config);
+    client.rxGetConnection().flatMapCompletable(conn -> {
+      Single<RowSet<Row>> setup = conn
+        .query("drop table folks if exists")
+        .rxExecute()
+        .flatMap(res -> conn
+          .query("create table folks (firstname varchar(255) not null)")
+          .rxExecute()
+        );
+      for (String name : NAMES) {
+        setup = setup.flatMap(res -> conn.query(String.format(INSERT_FOLK_SQL, name)).rxExecute());
+      }
+      return setup.ignoreElement().doFinally(conn::close);
+    }).blockingAwait();
+  }
+
+  @Test
+  public void testWithTransactionSuccess() throws Exception {
+    withTransaction(null).test()
+      .await()
+      .assertValue(namesWithExtraFolks());
+  }
+
+  @Test
+  public void testWithTransactionFailure() throws Exception {
+    Exception error = new Exception();
+    withTransaction(error).test()
+      .await()
+      .assertFailure(err -> error == err);
+    assertTableContainsInitDataOnly();
+  }
+
+  private Single<List<String>> withTransaction(Exception e) {
+    return client.rxWithTransaction((Function<SqlClient, Single<List<String>>>) sqlClient ->
+      rxInsertExtraFolks(sqlClient)
+        .flatMapPublisher(res -> uniqueNames(sqlClient))
+        .<List<String>>collect(ArrayList::new, List::add)
+        .compose(upstream -> e == null ? upstream : upstream.flatMap(names -> Single.error(e))));
+  }
+
+  protected Single<RowSet<Row>> rxInsertExtraFolks(SqlClient conn) {
+    return conn
+      .query(String.format(INSERT_FOLK_SQL, "Georges"))
+      .rxExecute()
+      .flatMap(res -> conn
+        .query(String.format(INSERT_FOLK_SQL, "Henry"))
+        .rxExecute()
+      );
+  }
+
+  protected Flowable<String> uniqueNames(SqlClient conn) {
+    return conn.query(UNIQUE_NAMES_SQL).rxExecute()
+      .flatMapPublisher(Flowable::fromIterable)
+      .map(row -> row.getString(0));
+  }
+
+  protected void assertTableContainsInitDataOnly() throws Exception {
+    client
+      .rxGetConnection()
+      .flatMapPublisher(conn -> uniqueNames(conn).doFinally(conn::close))
+      .test()
+      .await()
+      .assertComplete()
+      .assertValueSequence(NAMES.stream().sorted().distinct().collect(toList()));
+  }
+
+  protected List<String> namesWithExtraFolks() {
+    return Stream.concat(NAMES.stream(), Stream.of("Georges", "Henry")).sorted().distinct().collect(toList());
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    client.rxClose().blockingAwait();
+  }
+}


### PR DESCRIPTION
Integration Single and Function type with generation, e.g Single param is aliased into Future and `java.util.function.Function` will rewrite arguments and be thus aliased to `io.reactivex.functions.Function`:

```
void doSomething(Single s);
void doSomething(Future s);
```

```
void doSomething(Function<String, Single<String>> s);
void doSomething(io.reactivex.functions.Function<String, Future<String>> s);
```

This was already existing for `ReadStream` rewritten to `Flowable`

This allows `SqlClient#withTransaction(Function<SqlClient, Future<U>>)` to be rewritten to `SqlClient#withTransaction(io.reactivex.functions.Function<SqlClient, Single<U>>)`
