### PR TITLE
RxJava2: always propagate WS error to subscriber callback

### DIFF
--- a/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/WriteStreamSubscriberImpl.java
+++ b/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/WriteStreamSubscriberImpl.java
@@ -65,11 +65,11 @@ public class WriteStreamSubscriberImpl<R, T> implements WriteStreamSubscriber<R>
       return;
     }
     writeStream.exceptionHandler(t -> {
-      if (!setDone()) {
-        RxJavaPlugins.onError(t);
-        return;
+      setDone();
+      Subscription s = getSubscription();
+      if (s != null) {
+        s.cancel();
       }
-      getSubscription().cancel();
       Consumer<? super Throwable> c;
       synchronized (this) {
         c = this.writeStreamExceptionHandler;


### PR DESCRIPTION
Fixes #188

This was correctly implemented for RxJava 1 but not RxJava 2.
Added a test for both implementations.