### PR TITLE
docs(): fix wrong title level in document

### DIFF
--- a/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
+++ b/rx-java/src/main/asciidoc/vertx-rx/java/index.adoc
@@ -278,7 +278,7 @@ for you, it deploys a `Verticle` and returns an `Observable<String>` of the depl
 {@link examples.RxifiedExamples#deployVerticle}
 ----
 
-= Rxified API
+== Rxified API
 
 The _Rxified_ API is a code generated version of the Vert.x API, just like the _JavaScript_ or _Groovy_
 language. The API uses the `io.vertx.rxjava` prefix, for instance the `io.vertx.core.Vertx` class is

--- a/rx-java2/src/main/asciidoc/vertx-rx/java2/index.adoc
+++ b/rx-java2/src/main/asciidoc/vertx-rx/java2/index.adoc
@@ -278,7 +278,7 @@ To deploy existing Verticle instances, you can use {@link io.vertx.reactivex.cor
 {@link examples.RxifiedExamples#deployVerticle}
 ----
 
-= Rxified API
+== Rxified API
 
 The _Rxified_ API is a code generated version of the Vert.x API, just like the _JavaScript_ or _Groovy_
 language. The API uses the `io.vertx.rxjava` prefix, for instance the `io.vertx.core.Vertx` class is

--- a/rx-java3/src/main/asciidoc/vertx-rx/java3/index.adoc
+++ b/rx-java3/src/main/asciidoc/vertx-rx/java3/index.adoc
@@ -278,7 +278,7 @@ To deploy existing Verticle instances, you can use {@link io.vertx.rxjava3.core.
 {@link examples.RxifiedExamples#deployVerticle}
 ----
 
-= Rxified API
+== Rxified API
 
 The _rxified_ API is a code generated version of the Vert.x API. The API uses the `io.vertx.rxjava3` prefix, for instance
 the `io.vertx.core.Vertx` class is translated to the {@link io.vertx.rxjava3.core.Vertx} class.


### PR DESCRIPTION
Motivation:

According to the context in document, the subtitle "Rxified API" should have the same level as "Vert.x API for RxJava2"; but the former is in h1, the latter is in h2.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
