### PR TITLE
Added vertx-junit5-rx-java3 module

### DIFF
--- a/rx-junit5-providers/pom.xml
+++ b/rx-junit5-providers/pom.xml
@@ -31,6 +31,7 @@
   <modules>
     <module>vertx-junit5-rx-java</module>
     <module>vertx-junit5-rx-java2</module>
+    <module>vertx-junit5-rx-java3</module>
   </modules>
 
   <properties>

--- a/rx-junit5-providers/vertx-junit5-rx-java3/pom.xml
+++ b/rx-junit5-providers/vertx-junit5-rx-java3/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-rx-junit5-providers</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vertx-junit5-rx-java3</artifactId>
+  <name>Vert.x JUnit 5 RxJava3 support</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java3</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/rx-junit5-providers/vertx-junit5-rx-java3/src/main/java/io/vertx/junit5/rxjava3/VertxParameterProvider.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java3/src/main/java/io/vertx/junit5/rxjava3/VertxParameterProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.junit5.rxjava3;
+
+import io.vertx.core.VertxException;
+import io.vertx.junit5.ParameterClosingConsumer;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxExtensionParameterProvider;
+import io.vertx.rxjava3.core.Vertx;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+import java.util.concurrent.TimeoutException;
+
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_DURATION;
+import static io.vertx.junit5.VertxExtension.DEFAULT_TIMEOUT_UNIT;
+
+/**
+ * RxJava 3 Vertx parameter provider.
+ */
+public class VertxParameterProvider implements VertxExtensionParameterProvider<Vertx> {
+  @Override
+  public Class<Vertx> type() {
+    return Vertx.class;
+  }
+
+  @Override
+  public String key() {
+    return VertxExtension.VERTX_INSTANCE_KEY;
+  }
+
+  @Override
+  public Vertx newInstance(ExtensionContext extensionContext, ParameterContext parameterContext) {
+    return Vertx.vertx();
+  }
+
+  @Override
+  public ParameterClosingConsumer<Vertx> parameterClosingConsumer() {
+    return vertx -> {
+      try {
+        if (!vertx.rxClose().blockingAwait(DEFAULT_TIMEOUT_DURATION, DEFAULT_TIMEOUT_UNIT)) {
+          throw new TimeoutException("Closing the Vertx context timed out");
+        }
+      } catch (Throwable err) {
+        if (err instanceof RuntimeException) {
+          throw new VertxException(err.getCause());
+        } else if (err instanceof Exception) {
+          throw err;
+        } else {
+          throw new VertxException(err);
+        }
+      }
+    };
+  }
+}

--- a/rx-junit5-providers/vertx-junit5-rx-java3/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
+++ b/rx-junit5-providers/vertx-junit5-rx-java3/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
@@ -1,0 +1,1 @@
+io.vertx.junit5.rxjava3.VertxParameterProvider

--- a/rx-junit5-providers/vertx-junit5-rx-java3/src/test/java/io/vertx/junit5/rxjava3/RxJava3Test.java
+++ b/rx-junit5-providers/vertx-junit5-rx-java3/src/test/java/io/vertx/junit5/rxjava3/RxJava3Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.junit5.rxjava3;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava3.core.AbstractVerticle;
+import io.vertx.rxjava3.core.RxHelper;
+import io.vertx.rxjava3.core.Vertx;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+@DisplayName("Test the RxJava 3 support")
+class RxJava3Test {
+
+  @Test
+  @DisplayName("Check the injection of a /io.vertx.reactivex.core.Vertx/ instance")
+  void check_injection(Vertx vertx, VertxTestContext testContext) {
+    testContext.verify(() -> {
+      assertThat(vertx).isNotNull();
+      testContext.completeNow();
+    });
+  }
+
+  @Test
+  @DisplayName("Check the deployment and interaction of a Rx verticle")
+  void check_deployment_and_message_send(Vertx vertx, VertxTestContext testContext) {
+    RxHelper
+      .deployVerticle(vertx, new RxVerticle())
+      .flatMap(id -> vertx.eventBus().rxRequest("check", "Ok?"))
+      .subscribe(
+        message -> testContext.verify(() -> {
+          assertThat(message.body()).isEqualTo("Check!");
+          testContext.completeNow();
+        }),
+        testContext::failNow);
+  }
+
+  static class RxVerticle extends AbstractVerticle {
+
+    @Override
+    public void start() throws Exception {
+      vertx.eventBus().consumer("check", message -> message.reply("Check!"));
+    }
+  }
+}


### PR DESCRIPTION
Closes #260

This allows to use vertx-junit5 with Vertx RxJava 3 API