### PR TITLE
Fixes #200 ReadStreamSubscriber does not properly handle errors deliv…

### DIFF
--- a/rx-gen/src/test/java/io/vertx/lang/rx/test/ReadStreamSubscriberStaticsTestBase.java
+++ b/rx-gen/src/test/java/io/vertx/lang/rx/test/ReadStreamSubscriberStaticsTestBase.java
@@ -1,0 +1,99 @@
+package io.vertx.lang.rx.test;
+
+import io.vertx.core.streams.ReadStream;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+public abstract class ReadStreamSubscriberStaticsTestBase<T, F> extends VertxTestBase {
+
+  public abstract F emptyFlowable();
+
+  public abstract F emptyExceptionFlowable(String errorMessage);
+
+  public abstract F exceptionAfterDataFlowable(String errorMessage, Iterable<T> source);
+
+  public abstract F flowable(Iterable<T> source);
+
+  public abstract ReadStream<T> asReadStream(F flowable);
+
+  public abstract List<T> generateData(int count);
+
+  @Test
+  public void testEmptyFlowable() {
+    waitFor(1);
+    F flowable = emptyFlowable();
+    ReadStream<T> readStream = asReadStream(flowable);
+    readStream.exceptionHandler(this::fail);
+    readStream.endHandler(v -> complete());
+    readStream.handler(i -> fail("empty stream"));
+    await();
+  }
+
+  @Test
+  public void testEmtpyListFlowable() {
+    waitFor(1);
+    F flowable = flowable(Collections.emptyList());
+    ReadStream<T> readStream = asReadStream(flowable);
+    readStream.exceptionHandler(this::fail);
+    readStream.endHandler(v -> complete());
+    readStream.handler(i -> fail("empty stream"));
+    await();
+  }
+
+  @Test
+  public void testWithElements() {
+    List<T> data = generateData(5);
+    waitFor(data.size() + 1);
+    LinkedList<T> copy = new LinkedList<>(data);
+    F flowable = flowable(data);
+    ReadStream<T> readStream = asReadStream(flowable);
+    readStream.exceptionHandler(this::fail);
+    readStream.endHandler(v -> complete());
+    readStream.handler(i -> {
+      assertEquals(copy.poll(), i);
+      complete();
+    });
+    await();
+  }
+
+  @Test
+  public void testWithException() {
+    waitFor(2);
+    String errorMessage = "error msg";
+    F flowable = emptyExceptionFlowable(errorMessage);
+    ReadStream<T> readStream = asReadStream(flowable);
+    readStream.exceptionHandler(e -> {
+      assertEquals(errorMessage, e.getMessage());
+      complete();
+    });
+    readStream.endHandler(v -> complete());
+    readStream.handler(i -> fail("only error in stream"));
+    await();
+  }
+
+  @Test
+  public void testWithDataAndException() {
+    List<T> data = generateData(5);
+    waitFor(data.size() + 2);
+    LinkedList<T> copy = new LinkedList<>(data);
+    String errorMessage = "error msg";
+    F flowable = exceptionAfterDataFlowable(errorMessage, data);
+    ReadStream<T> readStream = asReadStream(flowable);
+    readStream.exceptionHandler(e -> {
+      assertEquals(errorMessage, e.getMessage());
+      assertTrue("all data elements should be received ahead of the exception", copy.isEmpty());
+      complete();
+    });
+    readStream.endHandler(v -> complete());
+    readStream.handler(i -> {
+      assertEquals(copy.poll(), i);
+      complete();
+    });
+    await();
+  }
+
+}

--- a/rx-java-gen/src/main/java/io/vertx/rx/java/ReadStreamSubscriber.java
+++ b/rx-java-gen/src/main/java/io/vertx/rx/java/ReadStreamSubscriber.java
@@ -59,11 +59,12 @@ public class ReadStreamSubscriber<R, J> extends Subscriber<R> implements ReadStr
 
   @Override
   public ReadStream<J> handler(Handler<J> handler) {
+    Consumer<Subscriber<R>> action;
     synchronized (this) {
       elementHandler = handler;
+      action = execOnHandler;
+      execOnHandler = s -> {};
     }
-    Consumer<Subscriber<R>> action = execOnHandler;
-    execOnHandler = s -> {};
     action.accept(this);
     checkStatus();
     return this;

--- a/rx-java-gen/src/main/java/io/vertx/rx/java/ReadStreamSubscriber.java
+++ b/rx-java-gen/src/main/java/io/vertx/rx/java/ReadStreamSubscriber.java
@@ -6,6 +6,7 @@ import rx.Observable;
 import rx.Subscriber;
 
 import java.util.ArrayDeque;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -31,11 +32,10 @@ public class ReadStreamSubscriber<R, J> extends Subscriber<R> implements ReadStr
   private static final Throwable DONE_SENTINEL = new Throwable();
 
   public static final int BUFFER_SIZE = 16;
+  private Consumer<Subscriber<R>> execOnHandler;
 
   public static <R, J> ReadStream<J> asReadStream(Observable<R> observable, Function<R, J> adapter) {
-    ReadStreamSubscriber<R, J> observer = new ReadStreamSubscriber<>(adapter);
-    observable.subscribe(observer);
-    return observer;
+    return new ReadStreamSubscriber<>(adapter, observable::subscribe);
   }
 
   private final Function<R, J> adapter;
@@ -48,7 +48,12 @@ public class ReadStreamSubscriber<R, J> extends Subscriber<R> implements ReadStr
   private int requested = 0;
 
   public ReadStreamSubscriber(Function<R, J> adapter) {
+    this(adapter, s -> {});
+  }
+
+  public ReadStreamSubscriber(Function<R, J> adapter, Consumer<Subscriber<R>> execOnHandler) {
     this.adapter = adapter;
+    this.execOnHandler = execOnHandler;
     request(0);
   }
 
@@ -57,6 +62,9 @@ public class ReadStreamSubscriber<R, J> extends Subscriber<R> implements ReadStr
     synchronized (this) {
       elementHandler = handler;
     }
+    Consumer<Subscriber<R>> action = execOnHandler;
+    execOnHandler = s -> {};
+    action.accept(this);
     checkStatus();
     return this;
   }

--- a/rx-java-gen/src/test/java/io/vertx/rx/java/test/ReadStreamSubscriberStaticsTest.java
+++ b/rx-java-gen/src/test/java/io/vertx/rx/java/test/ReadStreamSubscriberStaticsTest.java
@@ -1,0 +1,44 @@
+package io.vertx.rx.java.test;
+
+import io.vertx.core.streams.ReadStream;
+import io.vertx.lang.rx.test.ReadStreamSubscriberStaticsTestBase;
+import io.vertx.rx.java.ReadStreamSubscriber;
+import rx.Observable;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ReadStreamSubscriberStaticsTest extends ReadStreamSubscriberStaticsTestBase<Integer, Observable<Integer>> {
+
+  @Override
+  public Observable<Integer> emptyFlowable() {
+    return Observable.empty();
+  }
+
+  @Override
+  public List<Integer> generateData(int count) {
+    return IntStream.range(0, count).boxed().collect(Collectors.toList());
+  }
+
+  @Override
+  public Observable<Integer> flowable(Iterable<Integer> source) {
+    return Observable.from(source);
+  }
+
+  @Override
+  public ReadStream<Integer> asReadStream(Observable<Integer> flowable) {
+    return ReadStreamSubscriber.asReadStream(flowable, Function.identity());
+  }
+
+  @Override
+  public Observable<Integer> emptyExceptionFlowable(String errorMessage) {
+    return Observable.error(new RuntimeException(errorMessage));
+  }
+
+  @Override
+  public Observable<Integer> exceptionAfterDataFlowable(String errorMessage, Iterable<Integer> source) {
+    return flowable(source).concatWith(emptyExceptionFlowable(errorMessage));
+  }
+}

--- a/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/ReadStreamSubscriber.java
+++ b/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/ReadStreamSubscriber.java
@@ -68,11 +68,12 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
 
   @Override
   public ReadStream<J> handler(Handler<J> handler) {
+    Consumer<Subscriber<R>> action;
     synchronized (this) {
       elementHandler = handler;
+      action = execOnHandler;
+      execOnHandler = s -> {};
     }
-    Consumer<Subscriber<R>> action = execOnHandler;
-    execOnHandler = s -> {};
     action.accept(this);
     checkStatus();
     return this;

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/ReadStreamSubscriberStaticsTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/ReadStreamSubscriberStaticsTest.java
@@ -1,0 +1,44 @@
+package io.vertx.reactivex.test;
+
+import io.reactivex.Flowable;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.lang.rx.test.ReadStreamSubscriberStaticsTestBase;
+import io.vertx.reactivex.impl.ReadStreamSubscriber;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ReadStreamSubscriberStaticsTest extends ReadStreamSubscriberStaticsTestBase<Integer, Flowable<Integer>> {
+
+  @Override
+  public Flowable<Integer> emptyFlowable() {
+    return Flowable.empty();
+  }
+
+  @Override
+  public List<Integer> generateData(int count) {
+    return IntStream.range(0, count).boxed().collect(Collectors.toList());
+  }
+
+  @Override
+  public Flowable<Integer> flowable(Iterable<Integer> source) {
+    return Flowable.fromIterable(source);
+  }
+
+  @Override
+  public ReadStream<Integer> asReadStream(Flowable<Integer> flowable) {
+    return ReadStreamSubscriber.asReadStream(flowable, Function.identity());
+  }
+
+  @Override
+  public Flowable<Integer> emptyExceptionFlowable(String errorMessage) {
+    return Flowable.error(new RuntimeException(errorMessage));
+  }
+
+  @Override
+  public Flowable<Integer> exceptionAfterDataFlowable(String errorMessage, Iterable<Integer> source) {
+    return flowable(source).concatWith(emptyExceptionFlowable(errorMessage));
+  }
+}

--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
@@ -9,6 +9,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.util.ArrayDeque;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -30,15 +31,13 @@ import java.util.function.Function;
  */
 public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> {
 
-  private static final Runnable NOOP_ACTION = () -> {};
+  private static final Runnable NOOP_ACTION = () -> { };
   private static final Throwable DONE_SENTINEL = new Throwable();
 
   public static final int BUFFER_SIZE = 16;
 
   public static <R, J> ReadStream<J> asReadStream(Flowable<R> flowable, Function<R, J> adapter) {
-    ReadStreamSubscriber<R, J> observer = new ReadStreamSubscriber<>(adapter);
-    flowable.subscribe(observer);
-    return observer;
+    return new ReadStreamSubscriber<>(adapter, flowable::subscribe);
   }
 
   public static <R, J> ReadStream<J> asReadStream(Observable<R> observable, Function<R, J> adapter) {
@@ -54,9 +53,16 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
   private ArrayDeque<R> pending = new ArrayDeque<>();
   private int requested = 0;
   private Subscription subscription;
+  private Consumer<Subscriber<R>> execOnHandler;
 
   public ReadStreamSubscriber(Function<R, J> adapter) {
+    this(adapter, s -> { });
+  }
+
+
+  public ReadStreamSubscriber(Function<R, J> adapter, Consumer<Subscriber<R>> execOnHandler) {
     this.adapter = adapter;
+    this.execOnHandler = execOnHandler;
   }
 
   @Override
@@ -64,6 +70,9 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
     synchronized (this) {
       elementHandler = handler;
     }
+    Consumer<Subscriber<R>> action = execOnHandler;
+    execOnHandler = s -> {};
+    action.accept(this);
     checkStatus();
     return this;
   }

--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
@@ -67,11 +67,12 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
 
   @Override
   public ReadStream<J> handler(Handler<J> handler) {
+    Consumer<Subscriber<R>> action;
     synchronized (this) {
       elementHandler = handler;
+      action = execOnHandler;
+      execOnHandler = s -> {};
     }
-    Consumer<Subscriber<R>> action = execOnHandler;
-    execOnHandler = s -> {};
     action.accept(this);
     checkStatus();
     return this;

--- a/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/ReadStreamSubscriberStaticsTest.java
+++ b/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/ReadStreamSubscriberStaticsTest.java
@@ -1,0 +1,44 @@
+package io.vertx.rxjava3.test;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.lang.rx.test.ReadStreamSubscriberStaticsTestBase;
+import io.vertx.rxjava3.impl.ReadStreamSubscriber;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ReadStreamSubscriberStaticsTest extends ReadStreamSubscriberStaticsTestBase<Integer, Flowable<Integer>> {
+
+  @Override
+  public Flowable<Integer> emptyFlowable() {
+    return Flowable.empty();
+  }
+
+  @Override
+  public List<Integer> generateData(int count) {
+    return IntStream.range(0, count).boxed().collect(Collectors.toList());
+  }
+
+  @Override
+  public Flowable<Integer> flowable(Iterable<Integer> source) {
+    return Flowable.fromIterable(source);
+  }
+
+  @Override
+  public ReadStream<Integer> asReadStream(Flowable<Integer> flowable) {
+    return ReadStreamSubscriber.asReadStream(flowable, Function.identity());
+  }
+
+  @Override
+  public Flowable<Integer> emptyExceptionFlowable(String errorMessage) {
+    return Flowable.error(new RuntimeException(errorMessage));
+  }
+
+  @Override
+  public Flowable<Integer> exceptionAfterDataFlowable(String errorMessage, Iterable<Integer> source) {
+    return flowable(source).concatWith(emptyExceptionFlowable(errorMessage));
+  }
+}


### PR DESCRIPTION
Motivation:

Currently in ReadStreamSubscriber#asReadStream the given Observable/Flowable is directly subscribed to which leads to an IllegalStateException should it only deliver an exception or is empty.
This change will subscribe to the give Observable/Flowable only on a call to ReadStreamSubscriber#handler which also conforms better to the ReadStream specification as it should only start to deliver elements as a handler is set.