### PR TITLE
Use DelegatingHandler for Handler params

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -765,23 +765,9 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
         ClassKind eventKind = eventType.getKind();
         if (eventKind == ASYNC_RESULT) {
           TypeInfo resultType = ((ParameterizedTypeInfo) eventType).getArg(0);
-          String resultName = genTypeName(resultType);
-          return "new Handler<AsyncResult<" + resultName + ">>() {\n" +
-            "      public void handle(AsyncResult<" + resultName + "> ar) {\n" +
-            "        if (ar.succeeded()) {\n" +
-            "          " + expr + ".handle(io.vertx.core.Future.succeededFuture(" + genConvReturn(resultType, method, "ar.result()") + "));\n" +
-            "        } else {\n" +
-            "          " + expr + ".handle(io.vertx.core.Future.failedFuture(ar.cause()));\n" +
-            "        }\n" +
-            "      }\n" +
-            "    }";
+          return "new io.vertx.lang.rx.DelegatingHandler<>(" + expr + ", ar -> ar.map(event -> " + genConvReturn(resultType, method, "event") + "))";
         } else {
-          String eventName = genTypeName(eventType);
-          return "new Handler<" + eventName + ">() {\n" +
-            "      public void handle(" + eventName + " event) {\n" +
-            "        " + expr + ".handle(" + genConvReturn(eventType, method, "event") + ");\n" +
-            "      }\n" +
-            "    }";
+          return "new io.vertx.lang.rx.DelegatingHandler<>(" + expr + ", event -> " + genConvReturn(eventType, method, "event") + ")";
         }
       } else if (kind == FUNCTION) {
         TypeInfo argType = parameterizedTypeInfo.getArg(0);

--- a/rx-gen/src/main/java/io/vertx/lang/rx/DelegatingHandler.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/DelegatingHandler.java
@@ -1,0 +1,35 @@
+package io.vertx.lang.rx;
+
+import io.vertx.core.Handler;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class DelegatingHandler<U, V> implements Handler<U> {
+
+  private final Handler<V> handler;
+  private final Function<U, V> mapper;
+
+  public DelegatingHandler(Handler<V> handler, Function<U, V> mapper) {
+    this.handler = Objects.requireNonNull(handler);
+    this.mapper = Objects.requireNonNull(mapper);
+  }
+
+  @Override
+  public void handle(U event) {
+    handler.handle(mapper.apply(event));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DelegatingHandler<?, ?> that = (DelegatingHandler<?, ?>) o;
+    return handler.equals(that.handler);
+  }
+
+  @Override
+  public int hashCode() {
+    return handler.hashCode();
+  }
+}


### PR DESCRIPTION
Fixes #282

DelegatingHandler overrides hashCode/equals by invoking the delegate corresponding methods.
This fixes issues that we have when a handler can be added or removed from sets or lists.