### PR TITLE
Add optional dependency to micrometer-registry-prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
   <properties>
     <stack.version>4.3.5-SNAPSHOT</stack.version>
+    <micrometer.version>1.9.5</micrometer.version>
   </properties>
 
   <dependencyManagement>

--- a/rx-java/pom.xml
+++ b/rx-java/pom.xml
@@ -363,6 +363,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- Transitive dependency declared as optional in vertx-micrometer-metrics, and used in @GenIgnore API -->
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${micrometer.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-tcp-eventbus-bridge</artifactId>
       <optional>true</optional>
@@ -676,25 +683,25 @@
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-influx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-jmx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-graphite</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
         </dependencies>

--- a/rx-java2/pom.xml
+++ b/rx-java2/pom.xml
@@ -379,6 +379,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- Transitive dependency declared as optional in vertx-micrometer-metrics, and used in @GenIgnore API -->
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${micrometer.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-tcp-eventbus-bridge</artifactId>
       <optional>true</optional>
@@ -723,25 +730,25 @@
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-influx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-jmx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-graphite</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
         </dependencies>

--- a/rx-java3/pom.xml
+++ b/rx-java3/pom.xml
@@ -374,6 +374,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- Transitive dependency declared as optional in vertx-micrometer-metrics, and used in @GenIgnore API -->
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${micrometer.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-tcp-eventbus-bridge</artifactId>
       <optional>true</optional>
@@ -723,25 +730,25 @@
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-influx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-jmx</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
           <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-graphite</artifactId>
-            <version>1.0.0</version>
+            <version>${micrometer.version}</version>
             <optional>true</optional>
           </dependency>
         </dependencies>


### PR DESCRIPTION
PrometheusMeterRegistry class is used in `@GenIgnore` method. But `micrometer-registry-prometheus` is a transitive dependency marked optional in `vertx-micrometer-metrics`

It needs to be explicitly added here. Otherwise, the build fails.