### PR TITLE
ReadStreamSubscriber throws NPE if handler is set to null before subs…

### DIFF
--- a/rx-java/src/test/resources/test.txt
+++ b/rx-java/src/test/resources/test.txt
@@ -1,0 +1,3 @@
+Marseille
+Amsterdam
+Lyon

--- a/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/ReadStreamSubscriber.java
+++ b/rx-java2-gen/src/main/java/io/vertx/reactivex/impl/ReadStreamSubscriber.java
@@ -3,7 +3,6 @@ package io.vertx.reactivex.impl;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
-import io.reactivex.functions.Action;
 import io.vertx.core.Handler;
 import io.vertx.core.streams.ReadStream;
 import org.reactivestreams.Publisher;
@@ -11,7 +10,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.util.ArrayDeque;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -71,7 +69,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
         action = () -> publisher.subscribe(this);
       } else {
         Subscription s = subscription;
-        action = s::cancel;
+        action = s != null ? s::cancel : NOOP_ACTION;
       }
     }
     action.run();

--- a/rx-java2/src/test/resources/test.txt
+++ b/rx-java2/src/test/resources/test.txt
@@ -1,0 +1,3 @@
+Marseille
+Amsterdam
+Lyon

--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
@@ -10,7 +10,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import java.util.ArrayDeque;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -70,7 +69,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
         action = () -> publisher.subscribe(this);
       } else {
         Subscription s = subscription;
-        action = s::cancel;
+        action = s != null ? s::cancel : NOOP_ACTION;
       }
     }
     action.run();

--- a/rx-java3/src/test/resources/test.txt
+++ b/rx-java3/src/test/resources/test.txt
@@ -1,0 +1,3 @@
+Marseille
+Amsterdam
+Lyon


### PR DESCRIPTION
…cription

Fixes #4507

This can happen with some adapters that set the handler to null upon creation (e.g. Rxified `RecordParser`).