### PR TITLE
Generate `<p>`, not `<p/>`, in javadoc, self-closing element not allowed

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -676,7 +676,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
       writer.println("/**");
       Token.toHtml(doc.getTokens(), " *", this::renderLinkToHtml, "\n", writer);
       writer.println(" *");
-      writer.println(" * <p/>");
+      writer.println(" * <p>");
       writer.print(" * NOTE: This class has been automatically generated from the {@link ");
       writer.print(type.getName());
       writer.println(" original} non RX-ified interface using Vert.x codegen.");


### PR DESCRIPTION
Since JDK 8 javadoc requires strict HTML 4. A self-closing `<p/>` is no longer allowed and javadoc fails with
```
error: self-closing element not allowed
```

For details see https://stackoverflow.com/q/26049329

Replacing `<p/>` with `<p>` fixes the error.