### PR TITLE
feat: instrument vertx-web-openapi and vertx-web-openapi-router

### DIFF
--- a/rx-java2/pom.xml
+++ b/rx-java2/pom.xml
@@ -235,6 +235,16 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi-router</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-circuit-breaker</artifactId>
       <optional>true</optional>
     </dependency>
@@ -402,6 +412,11 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-openapi</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-grpc-common</artifactId>
       <optional>true</optional>
     </dependency>
@@ -558,6 +573,8 @@
             vertx-web-sstore-infinispan,
             vertx-web-graphql,
             vertx-web-validation,
+            vertx-web-openapi,
+            vertx-web-openapi-router,
             vertx-circuit-breaker,
             vertx-dropwizard-metrics,
             vertx-redis-client,
@@ -590,6 +607,7 @@
             vertx-micrometer-metrics,
             vertx-tcp-eventbus-bridge,
             vertx-json-schema,
+            vertx-openapi,
             vertx-grpc-common,
             vertx-grpc-server,
             vertx-grpc-client

--- a/rx-java3/pom.xml
+++ b/rx-java3/pom.xml
@@ -230,6 +230,16 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-openapi-router</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-circuit-breaker</artifactId>
       <optional>true</optional>
     </dependency>
@@ -397,6 +407,11 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-openapi</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-grpc-common</artifactId>
       <optional>true</optional>
     </dependency>
@@ -557,6 +572,8 @@
             vertx-web-sstore-infinispan,
             vertx-web-graphql,
             vertx-web-validation,
+            vertx-web-openapi,
+            vertx-web-openapi-router,
             vertx-circuit-breaker,
             vertx-dropwizard-metrics,
             vertx-redis-client,
@@ -589,6 +606,7 @@
             vertx-micrometer-metrics,
             vertx-tcp-eventbus-bridge,
             vertx-json-schema,
+            vertx-openapi,
             vertx-grpc-common,
             vertx-grpc-server,
             vertx-grpc-client,


### PR DESCRIPTION
add rx2 and rx3 support for vertx-web-openapi and vertx-web-openapi-router