### PR TITLE
300 - Fix potential race condition when the flowable runs on another thread

### DIFF
--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
@@ -3,7 +3,9 @@ package io.vertx.rxjava3.impl;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Observable;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.streams.ReadStream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -54,10 +56,12 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
   private int requested = 0;
   private Subscription subscription;
   private Publisher<R> publisher;
+  private Context readerContext;
 
   public ReadStreamSubscriber(Function<R, J> adapter, Publisher<R> publisher) {
     this.adapter = adapter;
     this.publisher = publisher;
+    this.readerContext = Vertx.currentContext();
   }
 
   @Override
@@ -110,7 +114,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
     synchronized (this) {
       subscription = s;
     }
-    checkStatus();
+    readerContext.runOnContext(unused -> checkStatus());
   }
 
   private void checkStatus() {
@@ -207,7 +211,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
       }
       completed = e;
     }
-    checkStatus();
+    readerContext.runOnContext(unused -> checkStatus());
   }
 
   @Override
@@ -215,6 +219,6 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
     synchronized (this) {
       pending.add(item);
     }
-    checkStatus();
+    readerContext.runOnContext(unused -> checkStatus());
   }
 }

--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/ReadStreamSubscriber.java
@@ -3,9 +3,7 @@ package io.vertx.rxjava3.impl;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Observable;
-import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.streams.ReadStream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -56,12 +54,10 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
   private int requested = 0;
   private Subscription subscription;
   private Publisher<R> publisher;
-  private Context readerContext;
 
   public ReadStreamSubscriber(Function<R, J> adapter, Publisher<R> publisher) {
     this.adapter = adapter;
     this.publisher = publisher;
-    this.readerContext = Vertx.currentContext();
   }
 
   @Override
@@ -114,7 +110,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
     synchronized (this) {
       subscription = s;
     }
-    readerContext.runOnContext(unused -> checkStatus());
+    checkStatus();
   }
 
   private void checkStatus() {
@@ -211,7 +207,7 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
       }
       completed = e;
     }
-    readerContext.runOnContext(unused -> checkStatus());
+    checkStatus();
   }
 
   @Override
@@ -219,6 +215,6 @@ public class ReadStreamSubscriber<R, J> implements Subscriber<R>, ReadStream<J> 
     synchronized (this) {
       pending.add(item);
     }
-    readerContext.runOnContext(unused -> checkStatus());
+    checkStatus();
   }
 }


### PR DESCRIPTION
Fixes this issue: https://github.com/vert-x3/vertx-rx/issues/300

When the flowable runs on another thread, `checkStatus` can be called from 2 threads: the reader one (usually an event loop) and the producer one (usually a worker thread). Although this method is synchronized, a race condition can still happen in the `handler.handle(...)` method because producer thread can catch up the execution of the reader one (and the other way around). This is safer then to ensure that only one thread produce elements of this ReadStream.

I chose the reader context as the one used to execute every event publications because it's the context we know about at the subscriber's creation.