### PR TITLE
Add toObservable/toSubscriber methods to WriteStream contract

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -166,6 +166,8 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
 
       if (type.getRaw().getName().equals("io.vertx.core.streams.ReadStream")) {
         genReadStream(type.getParams(), writer);
+      } else if (type.getRaw().getName().equals("io.vertx.core.streams.WriteStream")) {
+        genWriteStream(type.getParams(), writer);
       }
     }
 
@@ -330,6 +332,9 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
   }
 
   protected abstract void genReadStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer);
+
+  protected void genWriteStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer) {
+  }
 
   private void generateClassBody(ClassModel model, String constructor, PrintWriter writer) {
     ClassTypeInfo type = model.getType();

--- a/rx-java-gen/src/main/java/io/vertx/lang/rxjava/RxJavaGenerator.java
+++ b/rx-java-gen/src/main/java/io/vertx/lang/rxjava/RxJavaGenerator.java
@@ -198,6 +198,14 @@ class RxJavaGenerator extends Vertx3RxGeneratorBase {
   }
 
   @Override
+  protected void genWriteStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer) {
+    writer.print("  WriteStreamSubscriber<");
+    writer.print(typeParams.get(0).getName());
+    writer.println("> toSubscriber();");
+    writer.println();
+  }
+
+  @Override
   protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
     if (type.isParameterized() && type.getRaw().getName().equals("rx.Observable")) {
       String adapterFunction;

--- a/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
+++ b/rx-java2-gen/src/main/java/io/vertx/lang/reactivex/RxJava2Generator.java
@@ -208,6 +208,18 @@ class RxJava2Generator extends Vertx3RxGeneratorBase {
   }
 
   @Override
+  protected void genWriteStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer) {
+    writer.print("  WriteStreamObserver<");
+    writer.print(typeParams.get(0).getName());
+    writer.println("> toObserver();");
+    writer.println();
+    writer.print("  WriteStreamSubscriber<");
+    writer.print(typeParams.get(0).getName());
+    writer.println("> toSubscriber();");
+    writer.println();
+  }
+
+  @Override
   protected String genConvParam(TypeInfo type, MethodInfo method, String expr) {
     if (type.isParameterized() && (type.getRaw().getName().equals("io.reactivex.Flowable") || type.getRaw().getName().equals("io.reactivex.Observable"))) {
       ParameterizedTypeInfo parameterizedType = (ParameterizedTypeInfo) type;

--- a/rx-java3-gen/src/main/java/io/vertx/lang/rxjava3/RxJava3Generator.java
+++ b/rx-java3-gen/src/main/java/io/vertx/lang/rxjava3/RxJava3Generator.java
@@ -1,11 +1,7 @@
 package io.vertx.lang.rxjava3;
 
 import io.reactivex.rxjava3.core.Flowable;
-import io.vertx.codegen.ClassModel;
-import io.vertx.codegen.MethodInfo;
-import io.vertx.codegen.MethodKind;
-import io.vertx.codegen.ParamInfo;
-import io.vertx.codegen.TypeParamInfo;
+import io.vertx.codegen.*;
 import io.vertx.codegen.type.ClassKind;
 import io.vertx.codegen.type.ClassTypeInfo;
 import io.vertx.codegen.type.ParameterizedTypeInfo;
@@ -239,6 +235,18 @@ class RxJava3Generator extends AbstractRxGenerator {
     writer.print("  io.reactivex.rxjava3.core.Flowable<");
     writer.print(typeParams.get(0).getName());
     writer.println("> toFlowable();");
+    writer.println();
+  }
+
+  @Override
+  protected void genWriteStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer) {
+    writer.print("  WriteStreamObserver<");
+    writer.print(typeParams.get(0).getName());
+    writer.println("> toObserver();");
+    writer.println();
+    writer.print("  WriteStreamSubscriber<");
+    writer.print(typeParams.get(0).getName());
+    writer.println("> toSubscriber();");
     writer.println();
   }
 


### PR DESCRIPTION
See #306

The equivalent methods for ReadStream (toObservable/toFlowable) were there already.