### PR TITLE
Up-port of the rxJava3 fix regarding throwing undeliverable error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <micrometer.version>1.9.5</micrometer.version>
+    <micrometer.version>1.13.0</micrometer.version>
   </properties>
 
   <dependencyManagement>

--- a/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/WriteStreamSubscriberImpl.java
+++ b/rx-java3-gen/src/main/java/io/vertx/rxjava3/impl/WriteStreamSubscriberImpl.java
@@ -65,10 +65,7 @@ public class WriteStreamSubscriberImpl<R, T> implements WriteStreamSubscriber<R>
       return;
     }
     writeStream.exceptionHandler(t -> {
-      if (!setDone()) {
-        RxJavaPlugins.onError(t);
-        return;
-      }
+      setDone();
       getSubscription().cancel();
       Consumer<? super Throwable> c;
       synchronized (this) {

--- a/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/WriteStreamSubscriberTest.java
+++ b/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/WriteStreamSubscriberTest.java
@@ -186,13 +186,11 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
     assertTrue("Expected writeStream end method to be invoked", writeStream.endInvoked());
   }
 
-  @Ignore
   @Test
   public void testWriteStreamError() throws Exception {
     testWriteStreamError(false);
   }
 
-  @Ignore
   @Test
   public void testWriteStreamErrorAfterComplete() throws Exception {
     testWriteStreamError(true);
@@ -202,17 +200,17 @@ public class WriteStreamSubscriberTest extends VertxTestBase {
     waitFor(2);
     RuntimeException expected = new RuntimeException();
     FakeWriteStream writeStream = new FakeWriteStream(vertx).failAfterWrite(expected);
-    Observer<Integer> subscriber = RxHelper.toObserver(writeStream).onWriteStreamError(throwable -> {
+    Subscriber<Integer> subscriber = RxHelper.toSubscriber(writeStream).onWriteStreamError(throwable -> {
       assertThat(throwable, is(sameInstance(expected)));
       complete();
     });
-    Observable.<Integer>create(emitter -> {
+    Flowable.<Integer>create(emitter -> {
       emitter.setCancellable(this::complete);
       emitter.onNext(0);
       if (complete) {
         emitter.onComplete();
       }
-    })
+    }, BackpressureStrategy.MISSING)
       .observeOn(RxHelper.scheduler(vertx))
       .subscribeOn(RxHelper.scheduler(vertx))
       .subscribe(subscriber);


### PR DESCRIPTION
Fix rxJava 3 with the same fix as in https://github.com/vert-x3/vertx-rx/commit/9170efdbdf33322a09a16af9c1e7dbb736832f0a (see https://github.com/vert-x3/vertx-rx/pull/247)

RxJava3 has been forgotten when fixing this bug.

There is no need to call the RX onError handler since there is a potential Handler to call and the Subscriber is already done anyway