### PR TITLE
Mark Rx types as deprecated if needed

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -83,6 +83,10 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     writer.print(type.getName());
     writer.println(".class)");
 
+    if (model.isDeprecated()) {
+      writer.println("@Deprecated()");
+    }
+
     writer.print("public ");
     if (model.isConcrete()) {
       writer.print("class");
@@ -199,7 +203,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
 
     // Gen newInstance
     writer.print("  public static ");
-    if (type.getParams().size() > 0) {
+    if (!type.getParams().isEmpty()) {
       writer.print(genTypeParamsDecl(type));
       writer.print(" ");
     }
@@ -219,7 +223,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     writer.println();
 
     // Gen parameterized newInstance
-    if (type.getParams().size() > 0) {
+    if (!type.getParams().isEmpty()) {
       writer.print("  public static ");
       writer.print(genTypeParamsDecl(type));
       writer.print(" ");
@@ -379,7 +383,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     writer.print("  private final ");
     writer.print(Helper.getNonGenericType(model.getIfaceFQCN()));
     List<TypeParamInfo.Class> typeParams = model.getTypeParams();
-    if (typeParams.size() > 0) {
+    if (!typeParams.isEmpty()) {
       writer.print(typeParams.stream().map(TypeParamInfo.Class::getName).collect(joining(",", "<", ">")));
     }
     writer.println(" delegate;");
@@ -477,7 +481,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
       }
     }
     // Cosmetic space
-    if (methodTypeArgMap.size() > 0) {
+    if (!methodTypeArgMap.isEmpty()) {
       writer.println();
     }
 
@@ -538,13 +542,13 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
         }
         writer.println();
       }
-      if (deprecated != null && deprecated.length() > 0) {
+      if (deprecated != null && !deprecated.isEmpty()) {
         writer.print("   * @deprecated ");
         writer.println(deprecated);
       }
       writer.println("   */");
     }
-    if (method.isDeprecated() || deprecated != null && deprecated.length() > 0) {
+    if (method.isDeprecated() || deprecated != null && !deprecated.isEmpty()) {
       writer.println("  @Deprecated()");
     }
     writer.print("  ");
@@ -553,7 +557,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     if (method.isStaticMethod()) {
       writer.print("static ");
     }
-    if (method.getTypeParams().size() > 0) {
+    if (!method.getTypeParams().isEmpty()) {
       writer.print(method.getTypeParams().stream().map(TypeParamInfo::getName).collect(joining(", ", "<", ">")));
       writer.print(" ");
     }
@@ -962,7 +966,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
   }
 
   private String genTypeParamsDecl(ClassTypeInfo type) {
-    if (type.getParams().size() > 0) {
+    if (!type.getParams().isEmpty()) {
       return type.getParams().stream().map(TypeParamInfo::getName).collect(joining(",", "<", ">"));
     } else {
       return "";
@@ -1001,7 +1005,7 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
           /* todo find a way for translating the complete signature */
           ret += "#" + elt.getSimpleName().toString();
         }
-        if (label.length() > 0) {
+        if (!label.isEmpty()) {
           ret += " " + label;
         }
         ret += "}";

--- a/rx-java-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
+++ b/rx-java-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface DeprecatedMethod {
+
+  @Deprecated
+  void foo();
+
+}

--- a/rx-java-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
+++ b/rx-java-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+@Deprecated
+public interface DeprecatedType {
+
+  void foo();
+
+}

--- a/rx-java-gen/src/test/java/io/vertx/rx/java/test/DeprecationTest.java
+++ b/rx-java-gen/src/test/java/io/vertx/rx/java/test/DeprecationTest.java
@@ -1,0 +1,21 @@
+package io.vertx.rx.java.test;
+
+import io.vertx.rxjava.codegen.extra.DeprecatedMethod;
+import io.vertx.rxjava.codegen.extra.DeprecatedType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+@SuppressWarnings("deprecation")
+public class DeprecationTest {
+
+  @Test
+  public void testDeprecatedType() {
+    assertNotNull(DeprecatedType.class.getAnnotation(Deprecated.class));
+  }
+
+  @Test
+  public void testDeprecatedMethod() throws Exception {
+    assertNotNull(DeprecatedMethod.class.getMethod("foo").getAnnotation(Deprecated.class));
+  }
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface DeprecatedMethod {
+
+  @Deprecated
+  void foo();
+
+}

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+@Deprecated
+public interface DeprecatedType {
+
+  void foo();
+
+}

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/DeprecationTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/DeprecationTest.java
@@ -1,0 +1,21 @@
+package io.vertx.reactivex.test;
+
+import io.vertx.reactivex.codegen.extra.DeprecatedMethod;
+import io.vertx.reactivex.codegen.extra.DeprecatedType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+@SuppressWarnings("deprecation")
+public class DeprecationTest {
+
+  @Test
+  public void testDeprecatedType() {
+    assertNotNull(DeprecatedType.class.getAnnotation(Deprecated.class));
+  }
+
+  @Test
+  public void testDeprecatedMethod() throws Exception {
+    assertNotNull(DeprecatedMethod.class.getMethod("foo").getAnnotation(Deprecated.class));
+  }
+}

--- a/rx-java3-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
+++ b/rx-java3-gen/src/test/java/io/vertx/codegen/extra/DeprecatedMethod.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+public interface DeprecatedMethod {
+
+  @Deprecated
+  void foo();
+
+}

--- a/rx-java3-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
+++ b/rx-java3-gen/src/test/java/io/vertx/codegen/extra/DeprecatedType.java
@@ -1,0 +1,11 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+@VertxGen
+@Deprecated
+public interface DeprecatedType {
+
+  void foo();
+
+}

--- a/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/DeprecationTest.java
+++ b/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/DeprecationTest.java
@@ -1,0 +1,21 @@
+package io.vertx.rxjava3.test;
+
+import io.vertx.rxjava3.codegen.extra.DeprecatedMethod;
+import io.vertx.rxjava3.codegen.extra.DeprecatedType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+@SuppressWarnings("deprecation")
+public class DeprecationTest {
+
+  @Test
+  public void testDeprecatedType() {
+    assertNotNull(DeprecatedType.class.getAnnotation(Deprecated.class));
+  }
+
+  @Test
+  public void testDeprecatedMethod() throws Exception {
+    assertNotNull(DeprecatedMethod.class.getMethod("foo").getAnnotation(Deprecated.class));
+  }
+}


### PR DESCRIPTION
If the corresponding Vert.x API is deprecated, the Rx API must be deprecated as well.

This will help users upgrade their applications incrementally.