### PR TITLE
Upgrade to RxJava3 version 3.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>io.reactivex.rxjava3</groupId>
         <artifactId>rxjava</artifactId>
-        <version>3.0.13</version>
+        <version>3.1.10</version>
         <exclusions>
           <exclusion>
             <groupId>io.reactivestreams</groupId>


### PR DESCRIPTION
The previous version was released in 2021. This version change mandates a dependency update in Vert.x Infinispan too