### PR TITLE
ClassCastException thrown by stream methods on Iterable types (#336)

### DIFF
--- a/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/AbstractRxGenerator.java
@@ -357,6 +357,17 @@ public abstract class AbstractRxGenerator extends Generator<ClassModel> {
     }
   }
 
+  protected boolean isStreamMethod(ClassModel model, MethodInfo method) {
+    return model.isIterable() && method.getName().equals("stream") && method.getParams().isEmpty() && method.getReturnType().getRaw().getName().equals("java.util.stream.Stream");
+  }
+
+  protected void genStreamMethod(ClassModel model, PrintWriter writer) {
+    writer.printf("  public java.util.stream.Stream<%s> stream() {%n", genTranslatedTypeName(model.getIterableArg()));
+    writer.println("    return java.util.stream.StreamSupport.stream(spliterator(), false);");
+    writer.println("  }");
+    writer.println();
+  }
+
   protected abstract void genReadStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer);
 
   protected void genWriteStream(List<? extends TypeParamInfo> typeParams, PrintWriter writer) {

--- a/rx-gen/src/main/java/io/vertx/lang/rx/Vertx3RxGeneratorBase.java
+++ b/rx-gen/src/main/java/io/vertx/lang/rx/Vertx3RxGeneratorBase.java
@@ -28,6 +28,10 @@ public abstract class Vertx3RxGeneratorBase extends AbstractRxGenerator {
 
   @Override
   protected final void genMethods(ClassModel model, MethodInfo method, List<String> cacheDecls, boolean genBody, PrintWriter writer) {
+    if (isStreamMethod(model, method)) {
+      genStreamMethod(model, writer);
+      return;
+    }
     genMethod(model, method, cacheDecls, genBody, writer);
     MethodInfo overload = genOverloadedMethod(method);
     if (overload != null) {

--- a/rx-java2-gen/src/test/java/io/vertx/codegen/extra/IterableWithStreamMethod.java
+++ b/rx-java2-gen/src/test/java/io/vertx/codegen/extra/IterableWithStreamMethod.java
@@ -1,0 +1,27 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
+@VertxGen
+public interface IterableWithStreamMethod extends Iterable<Foo> {
+  @GenIgnore
+  class Impl implements IterableWithStreamMethod {
+    @Override
+    public Iterator<Foo> iterator() {
+      return Arrays.<Foo>asList(new Foo.Impl(), new Foo.Impl()).iterator();
+    }
+  }
+
+  @GenIgnore(PERMITTED_TYPE)
+  default Stream<Foo> stream() {
+    return StreamSupport.stream(spliterator(), false);
+  }
+}

--- a/rx-java2-gen/src/test/java/io/vertx/reactivex/test/StreamTest.java
+++ b/rx-java2-gen/src/test/java/io/vertx/reactivex/test/StreamTest.java
@@ -1,0 +1,15 @@
+package io.vertx.reactivex.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamTest {
+
+  @Test
+  public void testStream() {
+    io.vertx.codegen.extra.IterableWithStreamMethod bareInstance = new io.vertx.codegen.extra.IterableWithStreamMethod.Impl();
+    io.vertx.reactivex.codegen.extra.IterableWithStreamMethod rxInstance = io.vertx.reactivex.codegen.extra.IterableWithStreamMethod.newInstance(bareInstance);
+    assertEquals(2, rxInstance.stream().count());
+  }
+}

--- a/rx-java3-gen/src/main/java/io/vertx/lang/rxjava3/RxJava3Generator.java
+++ b/rx-java3-gen/src/main/java/io/vertx/lang/rxjava3/RxJava3Generator.java
@@ -151,6 +151,10 @@ class RxJava3Generator extends AbstractRxGenerator {
 
   @Override
   protected void genMethods(ClassModel model, MethodInfo method, List<String> cacheDecls, boolean genBody, PrintWriter writer) {
+    if (isStreamMethod(model, method)) {
+      genStreamMethod(model, writer);
+      return;
+    }
     if (method.getKind() == MethodKind.CALLBACK || method.getKind() == MethodKind.FUTURE) {
       genRxMethod(model, method, genBody, writer);
       genLazyRxMethod(model, method, genBody, writer);

--- a/rx-java3-gen/src/test/java/io/vertx/codegen/extra/IterableWithStreamMethod.java
+++ b/rx-java3-gen/src/test/java/io/vertx/codegen/extra/IterableWithStreamMethod.java
@@ -1,0 +1,27 @@
+package io.vertx.codegen.extra;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
+@VertxGen
+public interface IterableWithStreamMethod extends Iterable<Foo> {
+  @GenIgnore
+  class Impl implements IterableWithStreamMethod {
+    @Override
+    public Iterator<Foo> iterator() {
+      return Arrays.<Foo>asList(new Foo.Impl(), new Foo.Impl()).iterator();
+    }
+  }
+
+  @GenIgnore(PERMITTED_TYPE)
+  default Stream<Foo> stream() {
+    return StreamSupport.stream(spliterator(), false);
+  }
+}

--- a/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/StreamTest.java
+++ b/rx-java3-gen/src/test/java/io/vertx/rxjava3/test/StreamTest.java
@@ -1,0 +1,15 @@
+package io.vertx.rxjava3.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamTest {
+
+  @Test
+  public void testStream() {
+    io.vertx.codegen.extra.IterableWithStreamMethod bareInstance = new io.vertx.codegen.extra.IterableWithStreamMethod.Impl();
+    io.vertx.rxjava3.codegen.extra.IterableWithStreamMethod rxInstance = io.vertx.rxjava3.codegen.extra.IterableWithStreamMethod.newInstance(bareInstance);
+    assertEquals(2, rxInstance.stream().count());
+  }
+}


### PR DESCRIPTION
See #335

The exception is thrown if the iterable type argument is a Vert.x API type.

In this case, the type transformation is not applied (it's applied correctly for iterator methods).

The fix consists in generating a stream method that uses the iterator from the generated type, instead of invoking the delegate directly.